### PR TITLE
PrettyFormatter options

### DIFF
--- a/java/src/main/java/gherkin/formatter/PrettyFormatter.java
+++ b/java/src/main/java/gherkin/formatter/PrettyFormatter.java
@@ -63,17 +63,24 @@ public class PrettyFormatter implements Reporter, Formatter {
     private DescribedStatement statement;
 
 	private boolean rightAlignNumeric;
+	private boolean centerSteps;
+	private int centerSteps_maxKeywordLength;
 
     public PrettyFormatter(Appendable out, boolean monochrome, boolean executing) {
-        this(out, monochrome, executing, false);
+        this(out, monochrome, executing, false, false);
     }
 
-    public PrettyFormatter(Appendable out, boolean monochrome, boolean executing, boolean rightAlignNumeric) {
+    public PrettyFormatter(Appendable out, boolean monochrome, boolean executing, boolean rightAlignNumeric, boolean centerSteps) {
         this.out = new NiceAppendable(out);
         this.executing = executing;
         setMonochrome(monochrome);
         setRightAlignNumericValues(rightAlignNumeric);
+        setCenterSteps(centerSteps);
     }
+
+    public void setCenterSteps(boolean centerSteps) {
+		this.centerSteps = centerSteps;
+	}
 
 	public void setRightAlignNumericValues(boolean rightAlignNumeric) {
 		this.rightAlignNumeric = rightAlignNumeric;
@@ -135,6 +142,15 @@ public class PrettyFormatter implements Reporter, Formatter {
     }
 
     private void printSteps() {
+    	if (centerSteps) {
+    		centerSteps_maxKeywordLength = 0;
+    		for (Step step : steps) {
+				int length = step.getKeyword().length();
+				if (length > centerSteps_maxKeywordLength) {
+					centerSteps_maxKeywordLength = length;
+				}
+			}
+    	}
         while (!steps.isEmpty()) {
             if (matchesAndResults.isEmpty()) {
                 printStep("skipped", Collections.<Argument>emptyList(), null);
@@ -268,7 +284,14 @@ public class PrettyFormatter implements Reporter, Formatter {
         printComments(step.getComments(), "    ");
 
         StringBuilder buffer = new StringBuilder("    ");
-        buffer.append(textFormat.text(step.getKeyword()));
+        String keyword = step.getKeyword();
+        if (centerSteps) {
+        	int padLeft = centerSteps_maxKeywordLength - keyword.length();
+        	for (int i = 0; i < padLeft; i++) {
+        		buffer.append(" ");
+			}
+        }
+		buffer.append(textFormat.text(keyword));
         stepPrinter.writeStep(new NiceAppendable(buffer), textFormat, argFormat, step.getName(), arguments);
         buffer.append(indentedLocation(location));
 

--- a/java/src/test/java/gherkin/formatter/PrettyFormatterTest.java
+++ b/java/src/test/java/gherkin/formatter/PrettyFormatterTest.java
@@ -114,7 +114,8 @@ public class PrettyFormatterTest {
         String feature = featureBuilder.toString();
 
         boolean rightAlignNumeric = true;
-		List<String> lines = doFormatter(feature, rightAlignNumeric);
+		boolean centerSteps = false;
+		List<String> lines = doFormatter(feature, rightAlignNumeric, centerSteps);
 
         assertEquals("Formatter produces unexpected quantity of lines. ", 9, lines.size());
         
@@ -127,6 +128,34 @@ public class PrettyFormatterTest {
         assertEquals("      | extra long cucumber           |  10.95 |", lines.get(6));
         assertEquals("      | tiny cucumber                 |   2.95 |", lines.get(7));
         assertEquals("    Then should formatt beautifully.", lines.get(8));
+
+    }
+
+    @Test
+    public void shouldFormatAsDesignedWithCenterAlignedSteps() throws IOException {
+
+        StringBuilder featureBuilder = new StringBuilder();
+        featureBuilder.append("Feature: PrettyFormatter\n");
+        featureBuilder.append("Scenario: Format beautifully center-aligned steps\n");
+        featureBuilder.append("Given there are 12 cucumbers\n");
+        featureBuilder.append("When I eat 3 cucumbers\n");
+        featureBuilder.append("And I throw 2 cucumbers into the trash can\n");
+        featureBuilder.append("Then I should have 7 cucumbers\n");
+        String feature = featureBuilder.toString();
+
+        boolean rightAlignNumeric = false;
+		boolean centerSteps = true;
+		List<String> lines = doFormatter(feature, rightAlignNumeric, centerSteps);
+
+        assertEquals("Formatter produces unexpected quantity of lines. ", 7, lines.size());
+        
+        assertEquals("Feature: PrettyFormatter", lines.get(0));
+        assertEquals("", lines.get(1));
+        assertEquals("  Scenario: Format beautifully center-aligned steps", lines.get(2));
+        assertEquals("    Given there are 12 cucumbers", lines.get(3));
+        assertEquals("     When I eat 3 cucumbers", lines.get(4));
+        assertEquals("      And I throw 2 cucumbers into the trash can", lines.get(5));
+        assertEquals("     Then I should have 7 cucumbers", lines.get(6));
 
     }
 
@@ -380,14 +409,14 @@ public class PrettyFormatterTest {
      * @throws IOException
      */
     private List<String> doFormatter(String feature) throws IOException {
-    	return doFormatter(feature, false);
+    	return doFormatter(feature, false, false);
     }
-    private List<String> doFormatter(String feature, boolean rightAlignNumeric) throws IOException {
+    private List<String> doFormatter(String feature, boolean rightAlignNumeric, boolean centerSteps) throws IOException {
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream out = new PrintStream(baos);
 
-		Formatter formatter = new PrettyFormatter(out, true, false, rightAlignNumeric);
+		Formatter formatter = new PrettyFormatter(out, true, false, rightAlignNumeric, centerSteps);
         new Parser(formatter).parse(feature, "", 0);
         formatter.close();
 

--- a/java/src/test/java/gherkin/formatter/PrettyFormatterTest.java
+++ b/java/src/test/java/gherkin/formatter/PrettyFormatterTest.java
@@ -98,6 +98,37 @@ public class PrettyFormatterTest {
         assertEquals("    Then should formatt beautifully.", lines.get(6));
 
     }
+    
+    @Test
+    public void shouldFormatAsDesignedWithRightAlignedNumbers() throws IOException {
+
+        StringBuilder featureBuilder = new StringBuilder();
+        featureBuilder.append("Feature: PrettyFormatter\n");
+        featureBuilder.append("Scenario: Format beautifully right-aligned numbers in a data table\n");
+        featureBuilder.append("When I have this table:\n");
+        featureBuilder.append("\t|name|value|\n");
+        featureBuilder.append("\t|barel of extra long cucumbers|129.95|\n");
+        featureBuilder.append("\t|extra long cucumber|10.95|\n");
+        featureBuilder.append("\t|tiny cucumber|2.95|\n");
+        featureBuilder.append("Then should formatt beautifully.\n");
+        String feature = featureBuilder.toString();
+
+        boolean rightAlignNumeric = true;
+		List<String> lines = doFormatter(feature, rightAlignNumeric);
+
+        assertEquals("Formatter produces unexpected quantity of lines. ", 9, lines.size());
+        
+        assertEquals("Feature: PrettyFormatter", lines.get(0));
+        assertEquals("", lines.get(1));
+        assertEquals("  Scenario: Format beautifully right-aligned numbers in a data table", lines.get(2));
+        assertEquals("    When I have this table:", lines.get(3));
+        assertEquals("      | name                          | value  |", lines.get(4));
+        assertEquals("      | barel of extra long cucumbers | 129.95 |", lines.get(5));
+        assertEquals("      | extra long cucumber           |  10.95 |", lines.get(6));
+        assertEquals("      | tiny cucumber                 |   2.95 |", lines.get(7));
+        assertEquals("    Then should formatt beautifully.", lines.get(8));
+
+    }
 
     @Test
     public void shouldAppendOnlyCompleteLinesAndFlushBetween() throws IOException {
@@ -349,11 +380,14 @@ public class PrettyFormatterTest {
      * @throws IOException
      */
     private List<String> doFormatter(String feature) throws IOException {
+    	return doFormatter(feature, false);
+    }
+    private List<String> doFormatter(String feature, boolean rightAlignNumeric) throws IOException {
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream out = new PrintStream(baos);
 
-        Formatter formatter = new PrettyFormatter(out, true, false);
+		Formatter formatter = new PrettyFormatter(out, true, false, rightAlignNumeric);
         new Parser(formatter).parse(feature, "", 0);
         formatter.close();
 


### PR DESCRIPTION
This PR adds two optional formatting options to the `PrettyFormatter`. Both options default to `false` to not change the formatting result unless explicitly enabled.

#### right-align numeric values in tables
``` java
formatter.setRightAlignNumericValues(true);
```
``` gherkin
  Scenario: Format beautifully right-aligned numbers in a data table
    When I have this table:
      | name                          | value  |
      | barel of extra long cucumbers | 129.95 |
      | extra long cucumber           |  10.95 |
      | tiny cucumber                 |   2.95 |
```

#### center-align step keywords
``` java
formatter.setCenterSteps(true);
```
``` gherkin
  Scenario: Format beautifully center-aligned steps
    Given there are 12 cucumbers
     When I eat 3 cucumbers
      And I throw 2 cucumbers into the trash can
     Then I should have 7 cucumbers
```