### PR TITLE
Added another form of "and" in Spanish

### DIFF
--- a/lib/gherkin/i18n.json
+++ b/lib/gherkin/i18n.json
@@ -659,7 +659,7 @@
   },
   "es": {
     "but": "*|Pero",
-    "and": "*|Y",
+    "and": "*|Y|E",
     "then": "*|Entonces",
     "when": "*|Cuando",
     "name": "Spanish",


### PR DESCRIPTION
Added another form of "and" in Spanish, used when the second word in the sentence starts with an "i". So instead of writing:
"Y introduzco ..." you should write "E introduzco ..."