### PR TITLE
Stop the Perl exceptions from being prematurely stringified

### DIFF
--- a/perl/lib/Gherkin/Exceptions.pm
+++ b/perl/lib/Gherkin/Exceptions.pm
@@ -4,11 +4,10 @@ use warnings;
 package Gherkin::Exceptions;
 
 use overload
-  q{""}    => 'stringify',
-  fallback => 1;
+    q{""}    => 'stringify',
+    fallback => 1;
 
-sub stringify { my $self  = shift; $self->{'message'} . "\n" }
-sub message   { my $self  = shift; $self->{'message'} }
+sub stringify { my $self  = shift; $self->message . "\n" }
 sub throw     { my $class = shift; die $class->new(@_) }
 
 # Parent of single and composite exceptions
@@ -20,13 +19,17 @@ use base 'Gherkin::Exceptions';
 package Gherkin::Exceptions::CompositeParser;
 
 use base 'Gherkin::Exceptions::Parser';
+use Class::XSAccessor accessors => [qw/errors/];
 
 sub new {
-    my $class = shift;
-    bless {
-        message => join "\n",
-        ( 'Parser errors:', map { $_->{'message'} } @_ )
-    }, $class;
+    my ( $class, @errors ) = @_;
+    bless { errors => \@errors }, $class;
+}
+
+sub message {
+    my $self = shift;
+    return join "\n",
+        ( 'Parser errors:', map { $_->message } @{ $self->errors } );
 }
 
 sub throw { my $class = shift; die $class->new(@_) }
@@ -37,63 +40,100 @@ sub throw { my $class = shift; die $class->new(@_) }
 package Gherkin::Exceptions::SingleParser;
 
 use base 'Gherkin::Exceptions::Parser';
+use Class::XSAccessor accessors => [qw/location/];
 
-sub new {
-    my ( $class, $message, $location ) = @_;
-    bless {
-        message => sprintf( '(%i:%i): %s',
-            $location->{'line'}, $location->{'column'} || '0', $message ),
-    }, $class;
+sub message {
+    my $self = shift;
+    return sprintf( '(%i:%i): %s',
+        $self->location->{'line'},
+        ( $self->location->{'column'} || 0 ),
+        $self->detailed_message );
 }
 
 package Gherkin::Exceptions::NoSuchLanguage;
 
 use base 'Gherkin::Exceptions::SingleParser';
+use Class::XSAccessor accessors => [qw/language location/];
 
 sub new {
     my ( $class, $language, $location ) = @_;
-    return $class->SUPER::new( "Language not supported: $language",
-        $location, );
+    return bless { language => $language, location => $location }, $class;
+}
+
+sub detailed_message {
+    my $self = shift;
+    return "Language not supported: " . $self->language;
 }
 
 package Gherkin::Exceptions::AstBuilder;
 
 use base 'Gherkin::Exceptions::SingleParser';
+use Class::XSAccessor accessors => [qw/location ast_message/];
+
+sub new {
+    my ( $class, $ast_message, $location ) = @_;
+    return bless { ast_message => $ast_message, location => $location },
+        $class;
+}
+
+sub detailed_message {
+    my $self = shift;
+    return $self->ast_message;
+}
 
 package Gherkin::Exceptions::UnexpectedEOF;
 
 use base 'Gherkin::Exceptions::SingleParser';
+use Class::XSAccessor accessors => [qw/location expected_token_types/];
 
 sub new {
     my ( $class, $received_token, $expected_token_types ) = @_;
-    return $class->SUPER::new(
-        'unexpected end of file, expected: '
-          . ( join ', ', @$expected_token_types ),
-        $received_token->location,
-    );
+    return bless {
+        location             => $received_token->location,
+        received_token       => $received_token,
+        expected_token_types => $expected_token_types
+    }, $class;
+}
+
+sub detailed_message {
+    my $self = shift;
+    return "unexpected end of file, expected: " . join ', ',
+        @{ $self->expected_token_types };
 }
 
 package Gherkin::Exceptions::UnexpectedToken;
 
 use base 'Gherkin::Exceptions::SingleParser';
+use Class::XSAccessor accessors =>
+    [qw/location received_token_value expected_token_types state_comment/];
 
 sub new {
-    my ( $class, $received_token, $expected_token_types, $state_comment ) = @_;
+    my ( $class, $received_token, $expected_token_types, $state_comment )
+        = @_;
 
     my $received_token_value = $received_token->token_value;
     $received_token_value =~ s/^\s+//;
     $received_token_value =~ s/\s+$//;
 
-    my $message =
-        "expected: "
-      . ( join ', ', @$expected_token_types )
-      . ", got '$received_token_value'";
-
     my %location = %{ $received_token->location };
     $location{'column'} = $received_token->line->indent + 1
-      unless defined $location{'column'};
+        unless defined $location{'column'};
 
-    return $class->SUPER::new( $message, \%location );
+    return bless {
+        location             => \%location,
+        received_token_value => $received_token_value,
+        expected_token_types => $expected_token_types,
+        state_comment        => $state_comment,
+    }, $class;
+}
+
+sub detailed_message {
+    my $self = shift;
+    return sprintf(
+        "expected: %s, got '%s'",
+        ( join ', ', @{ $self->expected_token_types } ),
+        $self->received_token_value,
+    );
 }
 
 1;


### PR DESCRIPTION
In the previous implementation, structured error data was being
discarded at instantiation due to instant stringification in the
constructor; I believe this is how the Python implementation still
works. Changed the behaviour to maintain actual Exception objects
that know how to be stringified by default. This will allow
consumers the ability to catch and recover based on more than the
string itself, as well as giving consumers the ability to write
more comprehensive error messages should they wish to.

This also makes `Gherkin::Exceptions::SingleParser` an abstract class in practice, as it no longer has a constructor.

Braver developers than I might choose to investigate changing the other language implementations to work in a similar matter, but my opinion is that this isn't different enough from previous behaviour to mean they *have* to be changed.