### PR TITLE
Refactor "allow incomplete scenario outlines" for go.

### DIFF
--- a/go/ast.go
+++ b/go/ast.go
@@ -45,21 +45,17 @@ type Scenario struct {
 
 type ScenarioOutline struct {
 	ScenarioDefinition
-	Tags     []*Tag        `json:"tags"`
-	Examples []interface{} `json:"examples"`
+	Tags     []*Tag      `json:"tags"`
+	Examples []*Examples `json:"examples"`
 }
 
-type ExamplesBase struct {
+type Examples struct {
 	Node
 	Tags        []*Tag      `json:"tags"`
 	Keyword     string      `json:"keyword"`
 	Name        string      `json:"name"`
 	Description string      `json:"description,omitempty"`
-}
-
-type Examples struct {
-	ExamplesBase
-	TableHeader *TableRow   `json:"tableHeader"`
+	TableHeader *TableRow   `json:"tableHeader,omitempty"`
 	TableBody   []*TableRow `json:"tableBody"`
 }
 

--- a/go/astbuilder.go
+++ b/go/astbuilder.go
@@ -205,11 +205,6 @@ func (t *astBuilder) transformNode(node *astNode) (interface{}, error) {
 			}
 			scenarioOutlineLine := scenarioOutlineNode.getToken(TokenType_ScenarioOutlineLine)
 			description, _ := scenarioOutlineNode.getSingle(RuleType_Description).(string)
-			examples := scenarioOutlineNode.getItems(RuleType_Examples_Definition)
-			if examples == nil {
-				examples = []interface{}{}
-			}
-
 			sc := new(ScenarioOutline)
 			sc.Type = "ScenarioOutline"
 			sc.Tags = tags
@@ -218,7 +213,7 @@ func (t *astBuilder) transformNode(node *astNode) (interface{}, error) {
 			sc.Name = scenarioOutlineLine.Text
 			sc.Description = description
 			sc.Steps = astSteps(scenarioOutlineNode)
-			sc.Examples = examples
+			sc.Examples = astExamples(scenarioOutlineNode)
 			return sc, nil
 		}
 
@@ -229,28 +224,21 @@ func (t *astBuilder) transformNode(node *astNode) (interface{}, error) {
 		description, _ := examplesNode.getSingle(RuleType_Description).(string)
 		examplesTable := examplesNode.getSingle(RuleType_Examples_Table)
 
+		ex := new(Examples)
+		ex.Type = "Examples"
+		ex.Tags = tags
+		ex.Location = astLocation(examplesLine)
+		ex.Keyword = examplesLine.Keyword
+		ex.Name = examplesLine.Text
+		ex.Description = description
+		ex.TableHeader = nil
+		ex.TableBody = nil
 		if examplesTable != nil {
 			allRows, _ := examplesTable.([]*TableRow)
-			ex := new(Examples)
-	        	ex.Type = "Examples"
-	        	ex.Tags = tags
-	        	ex.Location = astLocation(examplesLine)
-	        	ex.Keyword = examplesLine.Keyword
-	        	ex.Name = examplesLine.Text
-	        	ex.Description = description
 			ex.TableHeader = allRows[0]
 			ex.TableBody = allRows[1:]
-	        	return ex, nil
-		} else {
-			ex := new(ExamplesBase)
-	        	ex.Type = "Examples"
-	        	ex.Tags = tags
-	        	ex.Location = astLocation(examplesLine)
-	        	ex.Keyword = examplesLine.Keyword
-	        	ex.Name = examplesLine.Text
-	        	ex.Description = description
-	        	return ex, nil
 		}
+		return ex, nil
 
 	case RuleType_Examples_Table:
 		allRows, err := astTableRows(node)
@@ -361,6 +349,16 @@ func astSteps(t *astNode) (steps []*Step) {
 	for i := range tokens {
 		step, _ := tokens[i].(*Step)
 		steps = append(steps, step)
+	}
+	return
+}
+
+func astExamples(t *astNode) (examples []*Examples) {
+	examples = []*Examples{}
+	tokens := t.getItems(RuleType_Examples_Definition)
+	for i := range tokens {
+		example, _ := tokens[i].(*Examples)
+		examples = append(examples, example)
 	}
 	return
 }

--- a/go/astjson.go
+++ b/go/astjson.go
@@ -1,0 +1,26 @@
+package gherkin
+
+import (
+	"encoding/json"
+)
+
+// To be consistent with the Gherkin parsers implemented in other languages
+// the TableBody attribute of an Examples struct should only be omitted if
+// it is null, not if it an empty list of TableRow:s.
+func (ex *Examples) MarshalJSON() ([]byte, error) {
+	type ExamplesAlias Examples
+	if ex.TableBody != nil {
+		return json.Marshal(&struct {
+			*ExamplesAlias
+		}{
+			ExamplesAlias:     (*ExamplesAlias)(ex),
+		})
+	} else {
+		return json.Marshal(&struct {
+			TableBody   []*TableRow `json:"tableBody,omitempty"`
+			*ExamplesAlias
+		}{
+			ExamplesAlias:     (*ExamplesAlias)(ex),
+		})
+	}
+}


### PR DESCRIPTION
Remove the extra ast class ExamplesBase and let a custom Json marshalling handle that the TableRow attribute of Examples shall be included in the Json output if it is an empty list, but it should not be included in the Json output if it has the value nil.

For a background, see the discussion starting here: https://github.com/cucumber/gherkin-go/commit/85ee76ba2fb6064c12f075d7733d21e7227a4c2d#commitcomment-16445193.