### PR TITLE
Ruby: Use require instead of require_relative

### DIFF
--- a/ruby/gherkin-ruby.razor
+++ b/ruby/gherkin-ruby.razor
@@ -26,10 +26,10 @@
 @helper MatchToken(TokenType tokenType)
 {<text>match_@(tokenType)(context, token)</text>}
 # This file is generated. Do not edit! Edit gherkin-ruby.razor instead.
-require_relative 'ast_builder'
-require_relative 'token_matcher'
-require_relative 'token_scanner'
-require_relative 'errors'
+require 'gherkin/ast_builder'
+require 'gherkin/token_matcher'
+require 'gherkin/token_scanner'
+require 'gherkin/errors'
 
 module Gherkin
 

--- a/ruby/lib/gherkin/ast_builder.rb
+++ b/ruby/lib/gherkin/ast_builder.rb
@@ -1,4 +1,4 @@
-require_relative 'ast_node'
+require 'gherkin/ast_node'
 
 module Gherkin
   class AstBuilder

--- a/ruby/lib/gherkin/parser.rb
+++ b/ruby/lib/gherkin/parser.rb
@@ -1,8 +1,8 @@
 # This file is generated. Do not edit! Edit gherkin-ruby.razor instead.
-require_relative 'ast_builder'
-require_relative 'token_matcher'
-require_relative 'token_scanner'
-require_relative 'errors'
+require 'gherkin/ast_builder'
+require 'gherkin/token_matcher'
+require 'gherkin/token_scanner'
+require 'gherkin/errors'
 
 module Gherkin
 

--- a/ruby/lib/gherkin/pickles/compiler.rb
+++ b/ruby/lib/gherkin/pickles/compiler.rb
@@ -1,4 +1,4 @@
-require_relative '../dialect'
+require 'gherkin/dialect'
 
 module Gherkin
   module Pickles

--- a/ruby/lib/gherkin/token_matcher.rb
+++ b/ruby/lib/gherkin/token_matcher.rb
@@ -1,5 +1,5 @@
-require_relative 'dialect'
-require_relative 'errors'
+require 'gherkin/dialect'
+require 'gherkin/errors'
 
 module Gherkin
   class TokenMatcher

--- a/ruby/lib/gherkin/token_scanner.rb
+++ b/ruby/lib/gherkin/token_scanner.rb
@@ -1,6 +1,6 @@
 require 'stringio'
-require_relative 'token'
-require_relative 'gherkin_line'
+require 'gherkin/token'
+require 'gherkin/gherkin_line'
 
 module Gherkin
   # The scanner reads a gherkin doc (typically read from a .feature file) and


### PR DESCRIPTION
The **gherkin** ruby gem use at various place `require_relative` to require other files from the gem.

As it happens that these files can be (and in fact are also) required by `require` elsewhere (for example directly in **cucumber-core**), this causes a discrepancy leading to these files being loaded twice.

Indeed, my ruby setup using rbenv on OS X relies on the fact that the main exposed directory for ruby is `/usr/local/opt/rbenv/versions/2.3.0/lib/ruby` which is a symbolic link for `/usr/local/Cellar/rbenv/1.0.0/versions/2.3.0/lib` (standard Homebrew + rbenv setup).

So `require 'gherkin/token_matcher'` ends up loading `/usr/local/opt/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/gherkin-3.2.0/lib/gherkin/token_matcher.rb` (once, even if required several times, due to the fact that require loads file once per path)
whereas in the **gherkin** gem `require_relative 'token_matcher'` resolves to `require '/usr/local/Cellar/rbenv/1.0.0/versions/2.3.0/lib/ruby/gems/2.3.0/gems/gherkin-3.2.0/lib/gherkin/token_matcher.rb'`, different from the previous version, and so, is loaded another time.

These are the warnings that annoyed me (and made me looking into it :laughing:) : 
```
➜ cucumber
/usr/local/Cellar/rbenv/1.0.0/versions/2.3.0/lib/ruby/gems/2.3.0/gems/gherkin-3.2.0/lib/gherkin/token_matcher.rb:6: warning: already initialized constant Gherkin::TokenMatcher::LANGUAGE_PATTERN
/usr/local/opt/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/gherkin-3.2.0/lib/gherkin/token_matcher.rb:6: warning: previous definition of LANGUAGE_PATTERN was here
/usr/local/opt/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/gherkin-3.2.0/lib/gherkin/dialect.rb:4: warning: already initialized constant Gherkin::DIALECT_FILE_PATH
/usr/local/Cellar/rbenv/1.0.0/versions/2.3.0/lib/ruby/gems/2.3.0/gems/gherkin-3.2.0/lib/gherkin/dialect.rb:4: warning: previous definition of DIALECT_FILE_PATH was here
/usr/local/opt/rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/gherkin-3.2.0/lib/gherkin/dialect.rb:5: warning: already initialized constant Gherkin::DIALECTS
/usr/local/Cellar/rbenv/1.0.0/versions/2.3.0/lib/ruby/gems/2.3.0/gems/gherkin-3.2.0/lib/gherkin/dialect.rb:5: warning: previous definition of DIALECTS was here
Using the default profile...
[...]
```

This humble PR aims to fix this :smiley:.