### PR TITLE
Correct typo of gherkin-languages.json file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ to import Mozilla certificates & solve the problem
 
 ## Adding or updating an i18n language
 
-1) Edit the file gherkin-lanauges.json.
+1) Edit the file gherkin-langauges.json.
 
 2) Distribute the changes to the different parser implementations, this requires `make`, `jq`, `diff`, but no compiler/interpreters:
 


### PR DESCRIPTION
In the Adding or updating an i18n language section the `gherkin-languages.json` file is referenced. There was a typo in the file which this commit corrects.