### PR TITLE
Add go as a build prerequisite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ Prerequisites:
 * Node.js or IO.js
 * Ruby
 * Python (both python2 & python3)
+* Go
 * `make`
 * `jq` (>= 1.4 for `--sort-keys` option)
 * `diff`


### PR DESCRIPTION
As mentioned in [issue 183](https://github.com/cucumber/gherkin/issues/183) `go` was not listed as a prerequisite for the build. This commit adds `go` to the list of prerequisites.