### PR TITLE
Fixed attribution error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
   ([#176](https://github.com/cucumber/gherkin/pull/176)
    by [charlierudolph])
 * (All) Don't make pickles out of step-less scenarios
-  ([#161](https://github.com/cucumber/gherkin/pull/175)
-   by [pjlsergeant])
+  ([#174](https://github.com/cucumber/gherkin/pull/175)
+   by [enkessler])
 * (Ruby) More consistent AST node types
   ([#158](https://github.com/cucumber/gherkin/pull/158)
    by [enkessler])


### PR DESCRIPTION
Corrected the links to the pull request and committer that did not
line up with the change to which they referred. Looks like it might
have been a copy/pasted from another change.