### PR TITLE
javascript: check for module before window

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -2,13 +2,13 @@
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define([], factory);
-  } else if (typeof window === 'object') {
-    // Browser globals (root is window)
-    window.Gherkin = factory();
-  } else {
-    // Node.js/IO.js
+  } else if (typeof module !== 'undefined' && module.exports) {
+    // Node.js/IO.js/RequireJS
     module.exports = factory();
-  }
+  } else {
+    // Browser globals (root is window)
+    root.Gherkin = factory();
+  } 
 }(this, function () {
   return {
     Parser: require('./lib/gherkin/parser'),


### PR DESCRIPTION
@aslakhellesoy 

for cucumber-js to work in the browser we browserify the code. The fact that window is checked for before module.exports breaks the browserified code.