### PR TITLE
Add tests for newlines in datatable cells

### DIFF
--- a/testdata/good/datatables.feature
+++ b/testdata/good/datatables.feature
@@ -7,7 +7,7 @@ Feature: DataTables
     And a data table with a single cell
       | foo |
     And a data table with different fromatting
-      |   foo|bar|    boz    |    
+      |   foo|bar|    boz    |
     And a data table with an empty cell
       |foo||boz|
     And a data table with comments and newlines inside
@@ -16,3 +16,6 @@ Feature: DataTables
       | boz  | boo  |
       # this is a comment
       | boz2 | boo2 |
+    And a data table with newlines inside cells
+      | foo\nzoo\nbaz | bar\nbaz\nboo |
+      | bar\nfoo      | baz           |

--- a/testdata/good/datatables.feature.ast.json
+++ b/testdata/good/datatables.feature.ast.json
@@ -316,6 +316,74 @@
             },
             "text": "a data table with comments and newlines inside",
             "type": "Step"
+          },
+          {
+            "argument": {
+              "location": {
+                "column": 7,
+                "line": 20
+              },
+              "rows": [
+                {
+                  "cells": [
+                    {
+                      "location": {
+                        "column": 9,
+                        "line": 20
+                      },
+                      "type": "TableCell",
+                      "value": "foo\nzoo\nbaz"
+                    },
+                    {
+                      "location": {
+                        "column": 25,
+                        "line": 20
+                      },
+                      "type": "TableCell",
+                      "value": "bar\nbaz\nboo"
+                    }
+                  ],
+                  "location": {
+                    "column": 7,
+                    "line": 20
+                  },
+                  "type": "TableRow"
+                },
+                {
+                  "cells": [
+                    {
+                      "location": {
+                        "column": 9,
+                        "line": 21
+                      },
+                      "type": "TableCell",
+                      "value": "bar\nfoo"
+                    },
+                    {
+                      "location": {
+                        "column": 25,
+                        "line": 21
+                      },
+                      "type": "TableCell",
+                      "value": "baz"
+                    }
+                  ],
+                  "location": {
+                    "column": 7,
+                    "line": 21
+                  },
+                  "type": "TableRow"
+                }
+              ],
+              "type": "DataTable"
+            },
+            "keyword": "And ",
+            "location": {
+              "column": 5,
+              "line": 19
+            },
+            "text": "a data table with newlines inside cells",
+            "type": "Step"
           }
         ],
         "tags": [],

--- a/testdata/good/datatables.feature.pickles.json
+++ b/testdata/good/datatables.feature.pickles.json
@@ -256,6 +256,62 @@
           }
         ],
         "text": "a data table with comments and newlines inside"
+      },
+      {
+        "arguments": [
+          {
+            "rows": [
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 20,
+                      "path": "../testdata/good/datatables.feature"
+                    },
+                    "value": "foo\nzoo\nbaz"
+                  },
+                  {
+                    "location": {
+                      "column": 25,
+                      "line": 20,
+                      "path": "../testdata/good/datatables.feature"
+                    },
+                    "value": "bar\nbaz\nboo"
+                  }
+                ]
+              },
+              {
+                "cells": [
+                  {
+                    "location": {
+                      "column": 9,
+                      "line": 21,
+                      "path": "../testdata/good/datatables.feature"
+                    },
+                    "value": "bar\nfoo"
+                  },
+                  {
+                    "location": {
+                      "column": 25,
+                      "line": 21,
+                      "path": "../testdata/good/datatables.feature"
+                    },
+                    "value": "baz"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "locations": [
+          {
+            "column": 9,
+            "line": 19,
+            "path": "../testdata/good/datatables.feature"
+          }
+        ],
+        "text": "a data table with newlines inside cells"
       }
     ],
     "tags": []

--- a/testdata/good/datatables.feature.tokens
+++ b/testdata/good/datatables.feature.tokens
@@ -16,4 +16,12 @@
 (16:7)TableRow://9:boz,16:boo
 (17:1)Comment:/      # this is a comment/
 (18:7)TableRow://9:boz2,16:boo2
+(19:5)StepLine:And /a data table with newlines inside cells/
+(20:7)TableRow://9:foo
+zoo
+baz,25:bar
+baz
+boo
+(21:7)TableRow://9:bar
+foo,25:baz
 EOF


### PR DESCRIPTION
Cucumber.js is still using Gherkin2 which exposes a bug with newline characters wrongly exposed in datatable cells. Gherkin4 is behaving correctly but this PR adds tests for that.

See https://github.com/cucumber/cucumber-js/issues/518