### PR TITLE
Bump minimum Perl version to 5.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include:
     - env: TARGET_LANG=perl
       language: perl
-      perl: "5.8"
+      perl: "5.14"
       install:
         - ( cd $TARGET_LANG; dzil authordeps --missing | cpanm --no-skip-satisfied )
         - ( cd $TARGET_LANG; dzil listdeps --author --missing | cpanm --no-skip-satisfied )

--- a/perl/dist.ini
+++ b/perl/dist.ini
@@ -4,7 +4,7 @@ main_module = lib/Gherkin.pm
 author    = ['Peter Sergeant <pete@clueball.com>', 'Cucumber Ltd', 'Gaspar Nagy']
 license   = MIT
 is_trial  = 0
-perl      = 5.008
+perl      = 5.14
 copyright_holder = Peter Sergeant, Cucumber Ltd, Gaspar Nagy
 
 [MetaResources]


### PR DESCRIPTION
https://travis-ci.org/cucumber/gherkin/jobs/138044300 failed because a dep required a newer version of Perl. 5.14 is now 5 years old, happy to bounce the minimum version up.