### PR TITLE
(Java) Make the jar a bundle to support execution in OSGi containers.

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.cucumber</groupId>
     <artifactId>gherkin</artifactId>
     <version>4.0.1-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>Gherkin</name>
     <description>Gherkin parser</description>
     <url>https://github.com/cucumber/gherkin-java</url>
@@ -86,6 +86,17 @@
                 <version>2.5.2</version>
                 <configuration>
                     <tagNameFormat>v@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.6</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>gherkin.*</Export-Package>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
With https://github.com/cucumber/gherkin2/pull/166 and https://github.com/cucumber/cucumber-jvm/pull/873 support to execute Cucumber-JVM in OSGi containers was added. To not lose that ability when upgrading Cucumber-JVM to use Gherkin v4, the Gherkin jar need to be built as an OSGi bundle.