### PR TITLE
Add JIRA related terms for `Feature` and 'Scenario`

### DIFF
--- a/gherkin-languages.json
+++ b/gherkin-languages.json
@@ -661,7 +661,9 @@
     ],
     "scenarioOutline": [
       "Scenario Outline",
-      "Scenario Template"
+      "Scenario Template",
+      "Story Outline",
+      "User Story Outline"
     ],
     "then": [
       "* ",


### PR DESCRIPTION
Our customer uses [JIRA](https://www.atlassian.com/software/jira). This tool uses different wording for `Feature` and `Scenario`. To avoid confusion when he reads and writes .FEATURE-files, JIRA terms are added to `gherkin-languages.json`.