### PR TITLE
Using full path when loading gherkin-languages.json

### DIFF
--- a/java/src/main/java/gherkin/GherkinDialectProvider.java
+++ b/java/src/main/java/gherkin/GherkinDialectProvider.java
@@ -16,7 +16,7 @@ public class GherkinDialectProvider implements IGherkinDialectProvider {
     static {
         Gson gson = new Gson();
         try {
-            Reader dialects = new InputStreamReader(GherkinDialectProvider.class.getResourceAsStream("gherkin-languages.json"), "UTF-8");
+            Reader dialects = new InputStreamReader(GherkinDialectProvider.class.getResourceAsStream("/gherkin/gherkin-languages.json"), "UTF-8");
             DIALECTS = gson.fromJson(dialects, Map.class);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
The class **GherkinDialectProvider** fails to load the **gherkin-languages.json** on **Android**. To fix that, the path should start with '**/**' and therefore contain the full path to the file.