### PR TITLE
elixir: Remove redundant Github Action

### DIFF
--- a/.github/workflows/test-elixir.yml
+++ b/.github/workflows/test-elixir.yml
@@ -21,9 +21,6 @@ jobs:
           otp-version: '22.2'
           elixir-version: '1.10.x'
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-
       - run: |
           mix local.hex --force
           mix deps.get


### PR DESCRIPTION
Protoc is not needed when building Gherkin
