### PR TITLE
perl: Use version range for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ## [Unreleased]
 ### Fixed
-- Link to the correct repository in various package meta-data. 
+- Link to the correct repository in various package meta-data.
+- [Perl] Specify version range for `Cucumber::Messages` dependency ([#50](https://github.com/cucumber/gherkin/pull/50))
 
 ## [25.0.2] - 2022-11-09
 ### Fixed

--- a/perl/cpanfile
+++ b/perl/cpanfile
@@ -2,7 +2,7 @@
 requires "perl", "5.14.0";
 requires "Cpanel::JSON::XS";
 requires "Class::XSAccessor";
-requires "Cucumber::Messages";
+requires "Cucumber::Messages", ">= 19.0.0, < 20.0.0";
 requires "Data::UUID";
 requires "Getopt::Long", "2.36";
 


### PR DESCRIPTION
### 🤔 What's changed?

We did not specify a version range for the Cucumber::Messages dependency. This wasn't a problem before, every version of message was usable. However once https://github.com/cucumber/common/pull/1741 was merged this was no longer true.

Fixes #48

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

I've used an lower and upper bound:

```
requires "Cucumber::Messages", ">= 19.0.0, < 20.0.0";
```

Perl does not appear to have JavaScripts equivalent for any later version within this major (e.g.  `^19.0.0`).

https://metacpan.org/pod/CPAN::Meta::Spec#Version-Ranges

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
