### PR TITLE
PHP - Add github auth token to composer configuration

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -10,6 +10,9 @@ on:
       - main
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test-php:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -25,6 +25,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Discover composer cache directory
         id: composer-cache


### PR DESCRIPTION
This writes the github auth token to a config file in ~/.composer, which then uses it when downloading packages

This will help with github rate limiting, as was happening on https://github.com/cucumber/gherkin/pull/52

Documentation here: https://github.com/shivammathur/setup-php#github-composer-authentication
