### PR TITLE
Allow messages v19.1.4 to v20.0.1 to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org).
 This document is formatted according to the principles of [Keep A CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+- [Javascript, PHP, Ruby] Allow messages v19.1.4 to v20.0.1 to be used
 
 ## [26.0.2] - 2022-12-27
 ### Fixed

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -40,7 +40,7 @@
     "typescript": "4.9.4"
   },
   "dependencies": {
-    "@cucumber/messages": "^21.0.0"
+    "@cucumber/messages": "19.1.4 - 21"
   },
   "directories": {
     "test": "test"

--- a/php/composer.json
+++ b/php/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^8.1",
         "ext-mbstring": "*",
-        "cucumber/messages": "^21.0"
+        "cucumber/messages": "19.1.4 - 21"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/ruby/cucumber-gherkin.gemspec
+++ b/ruby/cucumber-gherkin.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/cucumber/gherkin/blob/main/ruby'
   }
 
-  s.add_dependency 'cucumber-messages', '~> 19.1', '>= 19.1.4'
+  s.add_runtime_dependency 'cucumber-messages', '>= 19.1.4', '< 22.0'
 
   s.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
   s.add_development_dependency 'rspec', '~> 3.11', '>= 3.11.0'


### PR DESCRIPTION
### 🤔 What's changed?
Allow messages v19.1.4 to v20.0.1 to be used by Javascript, PHP and Ruby.

With v19 [the messages protocol was expanded with keyword types][1]. Since then no relevant changes for Gherkin have been made. This means we can expand the range of allowed message versions somewhat.

1: https://github.com/cucumber/messages/blob/main/CHANGELOG.md#1900---2022-05-31

The documentation for the syntax of each can be found here:
 - https://semver.npmjs.com/
 - https://getcomposer.org/doc/articles/versions.md
 - https://guides.rubygems.org/patterns/

Fixes: https://github.com/cucumber/gherkin/issues/82

### 🏷️ What kind of change is this?
- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
