### PR TITLE
ruby: introduce Gherkin::Query#parent_locations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 - (i18n) Added Danish translation of "Rule"
 - (i18n) Added Dutch translation of "Rule"
 - (i18n) Added Esperanto translation of "Rule"
+- [Ruby] Added `Gherkin::Query#parent_locations` for determining a scenario's parents' line numbers ([#89](https://github.com/cucumber/gherkin/pull/89))
 
 ## [26.2.0] - 2023-04-07
 ### Changed

--- a/ruby/lib/gherkin/query.rb
+++ b/ruby/lib/gherkin/query.rb
@@ -2,10 +2,17 @@ module Gherkin
   class Query
     def initialize
       @ast_node_locations = {}
+      @scenario_parent_locations = {}
+      @background_locations = {}
     end
 
     def update(message)
       update_feature(message.gherkin_document.feature) if message.gherkin_document
+    end
+
+    def scenario_parent_locations(scenario_node_id)
+      return @scenario_parent_locations[scenario_node_id] if @scenario_parent_locations.has_key?(scenario_node_id)
+      raise AstNodeNotLocatedException, "No scenario parent locations found for #{scenario_node_id} }. Known: #{@scenario_parent_locations.keys}"
     end
 
     def location(ast_node_id)
@@ -20,27 +27,27 @@ module Gherkin
       store_nodes_location(feature.tags)
 
       feature.children.each do |child|
-        update_rule(child.rule) if child.rule
-        update_background(child.background) if child.background
-        update_scenario(child.scenario) if child.scenario
+        update_rule(feature, child.rule) if child.rule
+        update_background(feature, child.background) if child.background
+        update_scenario(feature, child.rule, child.scenario) if child.scenario
       end
     end
 
-    def update_rule(rule)
+    def update_rule(feature, rule)
       return if rule.nil?
       store_nodes_location(rule.tags)
-
       rule.children.each do |child|
-        update_background(child.background) if child.background
-        update_scenario(child.scenario) if child.scenario
+        update_background(rule, child.background) if child.background
+        update_scenario(feature, rule, child.scenario) if child.scenario
       end
     end
 
-    def update_background(background)
+    def update_background(parent, background)
       update_steps(background.steps)
+      @background_locations[parent] = background.location
     end
 
-    def update_scenario(scenario)
+    def update_scenario(feature, rule, scenario)
       store_node_location(scenario)
       store_nodes_location(scenario.tags)
       update_steps(scenario.steps)
@@ -48,6 +55,13 @@ module Gherkin
         store_nodes_location(examples.tags || [])
         store_nodes_location(examples.table_body || [])
       end
+
+      @scenario_parent_locations[scenario.id] = [
+        feature.location,
+        @background_locations[feature],
+        rule&.location,
+        @background_locations[rule],
+      ].compact
     end
 
     def update_steps(steps)


### PR DESCRIPTION
### 🤔 What's changed?
Introduces a new Gherkin::Query#parent_locations method in the Ruby implementation.

Cucumber::Core::Compiler will use this method to tell Cucumber::Core::Test::Case the locations of its parent lines, such as `Feature:`, `Background:`, and `Rule:`, so that it will correctly match them during location filtering. This particular strategy was identified as potentially reasonable while pairing with @mattwynne.

### ⚡️ What's your motivation? 

This is one part of a two-repo PR to resolve the last remaining bits of the regression described in https://github.com/cucumber/cucumber-ruby/issues/1469

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [?] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [?] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

I'm not sure about these last two, since this could be considered as internals from a high-level cucumber point-of-view, but a public-interface addition from the gem point-of-view. Thoughts?