### PR TITLE
Fixed: Renovate/phpunit phpunit 10.x

### DIFF
--- a/php/composer.json
+++ b/php/composer.json
@@ -18,7 +18,7 @@
         "cucumber/messages": "19.1.4 - 21"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^10.0",
         "vimeo/psalm": "^5.0",
         "friendsofphp/php-cs-fixer": "^3.5",
         "psalm/plugin-phpunit": "^0.18.0",

--- a/php/phpunit.xml
+++ b/php/phpunit.xml
@@ -1,24 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         cacheResultFile=".phpunit.cache/test-results"
+         cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
-         beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         convertDeprecationsToExceptions="true"
          failOnRisky="true"
          failOnWarning="true"
-         verbose="true">
+         beStrictAboutCoverageMetadata="true">
     <testsuites>
         <testsuite name="default">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <coverage cacheDirectory=".phpunit.cache/code-coverage"
-              processUncoveredFiles="true">
+    <coverage>
         <include>
             <directory suffix=".php">src</directory>
         </include>

--- a/php/tests/Parser/RuleTypeTest.php
+++ b/php/tests/Parser/RuleTypeTest.php
@@ -18,7 +18,7 @@ final class RuleTypeTest extends TestCase
     /**
      * @return Generator<string,array{0:TokenType}>
      */
-    public function tokenCaseProvider(): Generator
+    public static function tokenCaseProvider(): Generator
     {
         foreach (TokenType::cases() as $case) {
             yield $case->name => [$case];


### PR DESCRIPTION
Replaces #93, migrates the phpunit XML config to the new schema and fixes a broken data provider (they now have to be static methods)