### PR TITLE
Added Danish translation of "Rule"

### DIFF
--- a/gherkin-languages.json
+++ b/gherkin-languages.json
@@ -630,7 +630,7 @@
     "name": "Danish",
     "native": "dansk",
     "rule": [
-      "Rule"
+      "Regel"
     ],
     "scenario": [
       "Eksempel",


### PR DESCRIPTION
Added translation of "Rule" in Danish: Regel.

A rule = En regel
More rules = Flere regler
