### PR TITLE
go: use standard header in generated file

### DIFF
--- a/go/dialects_builtin.go
+++ b/go/dialects_builtin.go
@@ -1,3 +1,5 @@
+// Code generated from dialects_builtin.go.jq (make dialects_builtin.go); DO NOT EDIT.
+
 package gherkin
 
 import messages "github.com/cucumber/messages/go/v21"

--- a/go/dialects_builtin.go.jq
+++ b/go/dialects_builtin.go.jq
@@ -86,7 +86,8 @@
   ]
   | add
   )
-| "package gherkin\n\n"
+| "// Code generated from dialects_builtin.go.jq (make dialects_builtin.go); DO NOT EDIT.\n\n" # Standard header defined at https://golang.org/s/generatedcode
++ "package gherkin\n\n"
 + "import messages \"github.com/cucumber/messages/go/v21\"\n\n"
 + "// Builtin dialects for " + ([ $root | to_entries[] | .key+" ("+.value.name+")" ] | join(", ")) + "\n"
 + "func DialectsBuiltin() DialectProvider {\n"


### PR DESCRIPTION
Use the standard header for Go generated files, following the spec at https://golang.org/s/generatedcode.

### 🤔 What's changed?

The template go/dialects_builtin.go.jq is fixed and go/dialects_builtin.go is regenerated.

### ⚡️ What's your motivation? 

The standard header allows automated tools or IDE to block editing directly generated files. That could help the renovatebot to stop doing invalid changes (see https://github.com/cucumber/gherkin/pull/120#issuecomment-1634352242 and https://github.com/renovatebot/renovate/issues/21010#issuecomment-1634377616).

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
