### PR TITLE
python: Remove Python 2.x from CI

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: [ '3.x', '2.x', 'pypy-3.8', 'pypy-2.7' ]
+        python-version: [ '3.x', 'pypy-3.8', 'pypy-2.7' ]
         # DISABLED: python-version: [ '3.x', '2.x' ]
         # include:
         #   - os: macos-latest


### PR DESCRIPTION
### 🤔 What's changed?

Removed Python 2.x from CI. Building with Python 2.x fails in CI due to deprecation

https://github.com/cucumber/gherkin/actions/runs/5545057411/jobs/10162291692?pr=134

```

Run actions/setup-python@v4
Installed versions
  Warning: The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672
  Version 2.x was not found in the local cache
  Error: The version '2.x' with architecture 'x64' was not found for Ubuntu 22.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

Related:
- https://github.com/cucumber/gherkin/issues/125
- https://github.com/cucumber/gherkin/issues/40