### PR TITLE
Perl add administrativia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 - [Go] Improve performance - don't compile regex on matcher create
 - [Perl] Fix release packaging
 - [Perl] Include CHANGELOG.md in tarball
+- [Perl] Upgrade messages to v22
 
 ### Added
 - (i18n) Add Malayalam localization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ### Changed
 - [Go] Upgraded messages to v22
 - [Go] Improve performance - don't compile regex on matcher create
+- [Perl] Fix release packaging
+- [Perl] Include CHANGELOG.md in tarball
 
 ### Added
 - (i18n) Add Malayalam localization

--- a/perl/cpanfile
+++ b/perl/cpanfile
@@ -2,7 +2,7 @@
 requires "perl", "5.14.4";
 requires "Cpanel::JSON::XS";
 requires "Class::XSAccessor";
-requires "Cucumber::Messages", ">= 19.0.0, < 20.0.0";
+requires "Cucumber::Messages", ">= 22.0.0, < 23.0.0";
 requires "Data::UUID";
 requires "Getopt::Long", "2.54";
 requires "List::Util", "1.63";

--- a/perl/dist.ini
+++ b/perl/dist.ini
@@ -21,6 +21,10 @@ repository.type   = git
 -remove=ConfirmRelease
 -remove=License
 -remove=GatherDir
+-remove=MakeMaker
+
+[MakeMaker]
+eumm_version = 7.1101
 
 [MetaJSON]
 [MetaProvides::Package]

--- a/perl/dist.ini
+++ b/perl/dist.ini
@@ -34,7 +34,8 @@ exclude_filename=VERSION
 
 [GatherFile]
 ; explicitly add unversioned files
-filename=../CHANGELOG.md
+root=../
+filename=CHANGELOG.md
 
 [Hook::VersionProvider]
 . = my $v = `cat ./VERSION`; chomp( $v ); $v;


### PR DESCRIPTION
### 🤔 What's changed?

Fixed release procedure:

* The packaging fails on the version range specified for "Cucumber::Messages"
* The CHANGELOG.md didn't actually get packaged

Also updated the Cucumber::Messages minimum version to v22 (in line with Go update).

### ⚡️ What's your motivation? 

I'd rather have the release procedure succeed :-)

### 🏷️ What kind of change is this?

:bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
