### PR TITLE
Errors once

### DIFF
--- a/perl/gherkin-perl.razor
+++ b/perl/gherkin-perl.razor
@@ -26,7 +26,7 @@
     return @state.Id;
 </text>}
 @helper MatchToken(TokenType tokenType)
-{<text>match_@(tokenType)($context, $token)</text>}
+{<text>$context->token_matcher->match_@(tokenType)($token)</text>}
 package Gherkin::Generated::@(Model.ParserClassName);
 
 # This file is generated. Do not edit! Edit gherkin-perl.razor instead.
@@ -94,18 +94,6 @@ sub _construct_parser_error {
     return $error_class->new( $token, @@args );
 }
 
-@foreach(var rule in Model.RuleSet.TokenRules)
-{<text>
-sub match_@(rule.Name.Replace("#", "")) {
-    my ($self, $context, $token) = @@_;
-    @if (rule.Name != "#EOF")
-    {
-    @:return if $token->is_eof;
-    }
-    $context->token_matcher->match_@(rule.Name.Replace("#", ""))( $token );
-}
-</text>}
-
 @foreach(var state in Model.States.Values.Where(s => !s.IsEndState)) //..
 {<text>
 # @Raw(state.Comment)
@@ -114,7 +102,7 @@ sub match_token_at_@(state.Id) {
     my ( $ok, $err );
     @foreach(var transition in state.Transitions)
     {
-    @:($ok, $err) = $self->@MatchToken(transition.TokenType);
+    @:($ok, $err) = @MatchToken(transition.TokenType);
     @:if ($ok) {
         @:$self->add_error( $context, $err ) if $err;
         if (transition.LookAheadHint != null)
@@ -157,11 +145,11 @@ sub lookahead_@(lookAheadHint.Id) {
         push( @@queue, $token );
 
         @foreach(var tokenType in lookAheadHint.ExpectedTokens) {<text>
-        ($match) = $self->@MatchToken(tokenType);
+        ($match) = @MatchToken(tokenType);
         last if $match;</text>}
 
         @foreach(var tokenType in lookAheadHint.Skip) {<text>
-        ($ok) = $self->@MatchToken(tokenType);
+        ($ok) = @MatchToken(tokenType);
         next if $ok;</text>
         }
 

--- a/perl/gherkin-perl.razor
+++ b/perl/gherkin-perl.razor
@@ -16,7 +16,7 @@
 }
 @helper HandleParserError(IEnumerable<string> expectedTokens, State state)
 {<text>    $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["@Raw(string.Join("\", \"", expectedTokens))"],
         "State: @state.Id - @Raw(state.Comment)",
@@ -102,10 +102,7 @@ sub match_@(rule.Name.Replace("#", "")) {
     {
     @:return if $token->is_eof;
     }
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_@(rule.Name.Replace("#", ""))( $token ) }
-    );
+    $context->token_matcher->match_@(rule.Name.Replace("#", ""))( $token );
 }
 </text>}
 
@@ -114,9 +111,12 @@ sub match_@(rule.Name.Replace("#", "")) {
 # @Raw(state.Comment)
 sub match_token_at_@(state.Id) {
     my ( $self, $token, $context ) = @@_;
+    my ( $ok, $err );
     @foreach(var transition in state.Transitions)
     {
-    @:if ($self->@MatchToken(transition.TokenType)) {
+    @:($ok, $err) = $self->@MatchToken(transition.TokenType);
+    @:if ($ok) {
+        @:$self->add_error( $context, $err ) if $err;
         if (transition.LookAheadHint != null)
         {
         @:if ($self->lookahead_@(transition.LookAheadHint.Id)($context, $token)) {
@@ -150,18 +150,19 @@ sub lookahead_@(lookAheadHint.Id) {
     my @@queue;
     my $match = 0;
 
+    my $ok;
     while (1) {
         $token = $context->read_token();
         $token->detach;
         push( @@queue, $token );
 
-        @foreach(var tokenType in lookAheadHint.ExpectedTokens) {
-        @:$match = 1 if $self->@MatchToken(tokenType);
-        }
-        last if $match;
+        @foreach(var tokenType in lookAheadHint.ExpectedTokens) {<text>
+        ($match) = $self->@MatchToken(tokenType);
+        last if $match;</text>}
 
-        @foreach(var tokenType in lookAheadHint.Skip) {
-        @:next if $self->@MatchToken(tokenType);
+        @foreach(var tokenType in lookAheadHint.Skip) {<text>
+        ($ok) = $self->@MatchToken(tokenType);
+        next if $ok;</text>
         }
 
         last;

--- a/perl/lib/Gherkin/Generated/Parser.pm
+++ b/perl/lib/Gherkin/Generated/Parser.pm
@@ -114,167 +114,138 @@ sub _construct_parser_error {
 
 sub match_EOF {
     my ($self, $context, $token) = @_;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_EOF( $token ) }
-    );
+    $context->token_matcher->match_EOF( $token );
 }
 
 sub match_Empty {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_Empty( $token ) }
-    );
+    $context->token_matcher->match_Empty( $token );
 }
 
 sub match_Comment {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_Comment( $token ) }
-    );
+    $context->token_matcher->match_Comment( $token );
 }
 
 sub match_TagLine {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_TagLine( $token ) }
-    );
+    $context->token_matcher->match_TagLine( $token );
 }
 
 sub match_FeatureLine {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_FeatureLine( $token ) }
-    );
+    $context->token_matcher->match_FeatureLine( $token );
 }
 
 sub match_RuleLine {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_RuleLine( $token ) }
-    );
+    $context->token_matcher->match_RuleLine( $token );
 }
 
 sub match_BackgroundLine {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_BackgroundLine( $token ) }
-    );
+    $context->token_matcher->match_BackgroundLine( $token );
 }
 
 sub match_ScenarioLine {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_ScenarioLine( $token ) }
-    );
+    $context->token_matcher->match_ScenarioLine( $token );
 }
 
 sub match_ExamplesLine {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_ExamplesLine( $token ) }
-    );
+    $context->token_matcher->match_ExamplesLine( $token );
 }
 
 sub match_StepLine {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_StepLine( $token ) }
-    );
+    $context->token_matcher->match_StepLine( $token );
 }
 
 sub match_DocStringSeparator {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_DocStringSeparator( $token ) }
-    );
+    $context->token_matcher->match_DocStringSeparator( $token );
 }
 
 sub match_TableRow {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_TableRow( $token ) }
-    );
+    $context->token_matcher->match_TableRow( $token );
 }
 
 sub match_Language {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_Language( $token ) }
-    );
+    $context->token_matcher->match_Language( $token );
 }
 
 sub match_Other {
     my ($self, $context, $token) = @_;
     return if $token->is_eof;
-    return $self->handle_external_error(
-        $context,
-        sub { $context->token_matcher->match_Other( $token ) }
-    );
+    $context->token_matcher->match_Other( $token );
 }
 
 
 # Start
 sub match_token_at_0 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Language($context, $token)) {
+    ($ok, $err) = $self->match_Language($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Feature');
         $self->_start_rule($context, 'FeatureHeader');
         $self->_build($context, $token);
         return 1;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Feature');
         $self->_start_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'Tags');
         $self->_build($context, $token);
         return 2;
     }
-    if ($self->match_FeatureLine($context, $token)) {
+    ($ok, $err) = $self->match_FeatureLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Feature');
         $self->_start_rule($context, 'FeatureHeader');
         $self->_build($context, $token);
         return 3;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 0;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 0;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Language", "#TagLine", "#FeatureLine", "#Comment", "#Empty"],
         "State: 0 - Start",
@@ -287,26 +258,35 @@ sub match_token_at_0 {
 # GherkinDocument:0>Feature:0>FeatureHeader:0>#Language:0
 sub match_token_at_1 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_TagLine($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Tags');
         $self->_build($context, $token);
         return 2;
     }
-    if ($self->match_FeatureLine($context, $token)) {
+    ($ok, $err) = $self->match_FeatureLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 3;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 1;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 1;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#TagLine", "#FeatureLine", "#Comment", "#Empty"],
         "State: 1 - GherkinDocument:0>Feature:0>FeatureHeader:0>#Language:0",
@@ -319,26 +299,35 @@ sub match_token_at_1 {
 # GherkinDocument:0>Feature:0>FeatureHeader:1>Tags:0>#TagLine:0
 sub match_token_at_2 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_TagLine($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 2;
     }
-    if ($self->match_FeatureLine($context, $token)) {
+    ($ok, $err) = $self->match_FeatureLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Tags');
         $self->_build($context, $token);
         return 3;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 2;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 2;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#TagLine", "#FeatureLine", "#Comment", "#Empty"],
         "State: 2 - GherkinDocument:0>Feature:0>FeatureHeader:1>Tags:0>#TagLine:0",
@@ -351,27 +340,38 @@ sub match_token_at_2 {
 # GherkinDocument:0>Feature:0>FeatureHeader:2>#FeatureLine:0
 sub match_token_at_3 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 3;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 5;
     }
-    if ($self->match_BackgroundLine($context, $token)) {
+    ($ok, $err) = $self->match_BackgroundLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'Background');
         $self->_build($context, $token);
         return 6;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -380,7 +380,9 @@ sub match_token_at_3 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'Rule');
         $self->_start_rule($context, 'RuleHeader');
@@ -388,28 +390,34 @@ sub match_token_at_3 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'Scenario');
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'Rule');
         $self->_start_rule($context, 'RuleHeader');
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
         $self->_build($context, $token);
         return 4;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Empty", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 3 - GherkinDocument:0>Feature:0>FeatureHeader:2>#FeatureLine:0",
@@ -422,26 +430,35 @@ sub match_token_at_3 {
 # GherkinDocument:0>Feature:0>FeatureHeader:3>DescriptionHelper:1>Description:0>#Other:0
 sub match_token_at_4 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'FeatureHeader');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 5;
     }
-    if ($self->match_BackgroundLine($context, $token)) {
+    ($ok, $err) = $self->match_BackgroundLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'Background');
         $self->_build($context, $token);
         return 6;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'FeatureHeader');
@@ -451,7 +468,9 @@ sub match_token_at_4 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'Rule');
@@ -460,7 +479,9 @@ sub match_token_at_4 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -468,7 +489,9 @@ sub match_token_at_4 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'Rule');
@@ -476,13 +499,15 @@ sub match_token_at_4 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 4;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 4 - GherkinDocument:0>Feature:0>FeatureHeader:3>DescriptionHelper:1>Description:0>#Other:0",
@@ -495,23 +520,32 @@ sub match_token_at_4 {
 # GherkinDocument:0>Feature:0>FeatureHeader:3>DescriptionHelper:2>#Comment:0
 sub match_token_at_5 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 5;
     }
-    if ($self->match_BackgroundLine($context, $token)) {
+    ($ok, $err) = $self->match_BackgroundLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'Background');
         $self->_build($context, $token);
         return 6;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -520,7 +554,9 @@ sub match_token_at_5 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'Rule');
         $self->_start_rule($context, 'RuleHeader');
@@ -528,27 +564,33 @@ sub match_token_at_5 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'Scenario');
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
         $self->_start_rule($context, 'Rule');
         $self->_start_rule($context, 'RuleHeader');
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 5;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Empty"],
         "State: 5 - GherkinDocument:0>Feature:0>FeatureHeader:3>DescriptionHelper:2>#Comment:0",
@@ -561,26 +603,37 @@ sub match_token_at_5 {
 # GherkinDocument:0>Feature:1>Background:0>#BackgroundLine:0
 sub match_token_at_6 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 6;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 8;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 9;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -589,7 +642,9 @@ sub match_token_at_6 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'Rule');
         $self->_start_rule($context, 'RuleHeader');
@@ -597,28 +652,34 @@ sub match_token_at_6 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'Scenario');
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'Rule');
         $self->_start_rule($context, 'RuleHeader');
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
         $self->_build($context, $token);
         return 7;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Empty", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 6 - GherkinDocument:0>Feature:1>Background:0>#BackgroundLine:0",
@@ -631,25 +692,34 @@ sub match_token_at_6 {
 # GherkinDocument:0>Feature:1>Background:1>DescriptionHelper:1>Description:0>#Other:0
 sub match_token_at_7 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 8;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 9;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Background');
@@ -659,7 +729,9 @@ sub match_token_at_7 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'Rule');
@@ -668,7 +740,9 @@ sub match_token_at_7 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -676,7 +750,9 @@ sub match_token_at_7 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'Rule');
@@ -684,13 +760,15 @@ sub match_token_at_7 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 7;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 7 - GherkinDocument:0>Feature:1>Background:1>DescriptionHelper:1>Description:0>#Other:0",
@@ -703,22 +781,31 @@ sub match_token_at_7 {
 # GherkinDocument:0>Feature:1>Background:1>DescriptionHelper:2>#Comment:0
 sub match_token_at_8 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 8;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 9;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -727,7 +814,9 @@ sub match_token_at_8 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'Rule');
         $self->_start_rule($context, 'RuleHeader');
@@ -735,27 +824,33 @@ sub match_token_at_8 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'Scenario');
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'Rule');
         $self->_start_rule($context, 'RuleHeader');
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 8;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Empty"],
         "State: 8 - GherkinDocument:0>Feature:1>Background:1>DescriptionHelper:2>#Comment:0",
@@ -768,30 +863,41 @@ sub match_token_at_8 {
 # GherkinDocument:0>Feature:1>Background:2>Step:0>#StepLine:0
 sub match_token_at_9 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DataTable');
         $self->_build($context, $token);
         return 10;
     }
-    if ($self->match_DocStringSeparator($context, $token)) {
+    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DocString');
         $self->_build($context, $token);
         return 49;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 9;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -801,7 +907,9 @@ sub match_token_at_9 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'Rule');
@@ -810,7 +918,9 @@ sub match_token_at_9 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -818,7 +928,9 @@ sub match_token_at_9 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'Rule');
@@ -826,17 +938,21 @@ sub match_token_at_9 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 9;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 9;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 9 - GherkinDocument:0>Feature:1>Background:2>Step:0>#StepLine:0",
@@ -849,7 +965,10 @@ sub match_token_at_9 {
 # GherkinDocument:0>Feature:1>Background:2>Step:1>StepArg:0>__alt0:0>DataTable:0>#TableRow:0
 sub match_token_at_10 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -857,18 +976,24 @@ sub match_token_at_10 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 10;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 9;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
@@ -879,7 +1004,9 @@ sub match_token_at_10 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -889,7 +1016,9 @@ sub match_token_at_10 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -898,7 +1027,9 @@ sub match_token_at_10 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -907,17 +1038,21 @@ sub match_token_at_10 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 10;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 10;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#TableRow", "#StepLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 10 - GherkinDocument:0>Feature:1>Background:2>Step:1>StepArg:0>__alt0:0>DataTable:0>#TableRow:0",
@@ -930,27 +1065,36 @@ sub match_token_at_10 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:0>Tags:0>#TagLine:0
 sub match_token_at_11 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_TagLine($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 11;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Tags');
         $self->_start_rule($context, 'Scenario');
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 11;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 11;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#TagLine", "#ScenarioLine", "#Comment", "#Empty"],
         "State: 11 - GherkinDocument:0>Feature:2>ScenarioDefinition:0>Tags:0>#TagLine:0",
@@ -963,27 +1107,38 @@ sub match_token_at_11 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:0>#ScenarioLine:0
 sub match_token_at_12 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 14;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 15;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_start_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'Tags');
@@ -991,7 +1146,9 @@ sub match_token_at_12 {
         return 17;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -1001,7 +1158,9 @@ sub match_token_at_12 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'Rule');
@@ -1010,13 +1169,17 @@ sub match_token_at_12 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'Examples');
         $self->_build($context, $token);
         return 18;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -1024,7 +1187,9 @@ sub match_token_at_12 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'Rule');
@@ -1032,14 +1197,16 @@ sub match_token_at_12 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
         $self->_build($context, $token);
         return 13;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Empty", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 12 - GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:0>#ScenarioLine:0",
@@ -1052,7 +1219,10 @@ sub match_token_at_12 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:1>DescriptionHelper:1>Description:0>#Other:0
 sub match_token_at_13 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -1060,18 +1230,24 @@ sub match_token_at_13 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 14;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 15;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'Description');
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -1080,7 +1256,9 @@ sub match_token_at_13 {
         return 17;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Scenario');
@@ -1091,7 +1269,9 @@ sub match_token_at_13 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -1101,14 +1281,18 @@ sub match_token_at_13 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_start_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'Examples');
         $self->_build($context, $token);
         return 18;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -1117,7 +1301,9 @@ sub match_token_at_13 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -1126,13 +1312,15 @@ sub match_token_at_13 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 13;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 13 - GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:1>DescriptionHelper:1>Description:0>#Other:0",
@@ -1145,23 +1333,32 @@ sub match_token_at_13 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:1>DescriptionHelper:2>#Comment:0
 sub match_token_at_14 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 14;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 15;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_start_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'Tags');
@@ -1169,7 +1366,9 @@ sub match_token_at_14 {
         return 17;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -1179,7 +1378,9 @@ sub match_token_at_14 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'Rule');
@@ -1188,13 +1389,17 @@ sub match_token_at_14 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'Examples');
         $self->_build($context, $token);
         return 18;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -1202,7 +1407,9 @@ sub match_token_at_14 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'Rule');
@@ -1210,13 +1417,15 @@ sub match_token_at_14 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 14;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Empty"],
         "State: 14 - GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:1>DescriptionHelper:2>#Comment:0",
@@ -1229,7 +1438,10 @@ sub match_token_at_14 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:2>Step:0>#StepLine:0
 sub match_token_at_15 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -1237,23 +1449,31 @@ sub match_token_at_15 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DataTable');
         $self->_build($context, $token);
         return 16;
     }
-    if ($self->match_DocStringSeparator($context, $token)) {
+    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DocString');
         $self->_build($context, $token);
         return 47;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 15;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -1262,7 +1482,9 @@ sub match_token_at_15 {
         return 17;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -1273,7 +1495,9 @@ sub match_token_at_15 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -1283,14 +1507,18 @@ sub match_token_at_15 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'Examples');
         $self->_build($context, $token);
         return 18;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -1299,7 +1527,9 @@ sub match_token_at_15 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -1308,17 +1538,21 @@ sub match_token_at_15 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 15;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 15;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 15 - GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:2>Step:0>#StepLine:0",
@@ -1331,7 +1565,10 @@ sub match_token_at_15 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:2>Step:1>StepArg:0>__alt0:0>DataTable:0>#TableRow:0
 sub match_token_at_16 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -1340,18 +1577,24 @@ sub match_token_at_16 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 16;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 15;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
@@ -1361,7 +1604,9 @@ sub match_token_at_16 {
         return 17;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
@@ -1373,7 +1618,9 @@ sub match_token_at_16 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -1384,7 +1631,9 @@ sub match_token_at_16 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -1392,7 +1641,9 @@ sub match_token_at_16 {
         $self->_build($context, $token);
         return 18;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -1402,7 +1653,9 @@ sub match_token_at_16 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -1412,17 +1665,21 @@ sub match_token_at_16 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 16;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 16;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#TableRow", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 16 - GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:2>Step:1>StepArg:0>__alt0:0>DataTable:0>#TableRow:0",
@@ -1435,27 +1692,36 @@ sub match_token_at_16 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:0>Tags:0>#TagLine:0
 sub match_token_at_17 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_TagLine($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 17;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Tags');
         $self->_start_rule($context, 'Examples');
         $self->_build($context, $token);
         return 18;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 17;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 17;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#TagLine", "#ExamplesLine", "#Comment", "#Empty"],
         "State: 17 - GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:0>Tags:0>#TagLine:0",
@@ -1468,7 +1734,10 @@ sub match_token_at_17 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:0>#ExamplesLine:0
 sub match_token_at_18 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -1477,20 +1746,28 @@ sub match_token_at_18 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 18;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 20;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesTable');
         $self->_build($context, $token);
         return 21;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1500,7 +1777,9 @@ sub match_token_at_18 {
         return 17;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1512,7 +1791,9 @@ sub match_token_at_18 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -1523,7 +1804,9 @@ sub match_token_at_18 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -1531,7 +1814,9 @@ sub match_token_at_18 {
         $self->_build($context, $token);
         return 18;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -1541,7 +1826,9 @@ sub match_token_at_18 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -1551,14 +1838,16 @@ sub match_token_at_18 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
         $self->_build($context, $token);
         return 19;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Empty", "#Comment", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 18 - GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:0>#ExamplesLine:0",
@@ -1571,7 +1860,10 @@ sub match_token_at_18 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:1>DescriptionHelper:1>Description:0>#Other:0
 sub match_token_at_19 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1581,18 +1873,24 @@ sub match_token_at_19 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 20;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_start_rule($context, 'ExamplesTable');
         $self->_build($context, $token);
         return 21;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
@@ -1603,7 +1901,9 @@ sub match_token_at_19 {
         return 17;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
@@ -1616,7 +1916,9 @@ sub match_token_at_19 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1628,7 +1930,9 @@ sub match_token_at_19 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1637,7 +1941,9 @@ sub match_token_at_19 {
         $self->_build($context, $token);
         return 18;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1648,7 +1954,9 @@ sub match_token_at_19 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1659,13 +1967,15 @@ sub match_token_at_19 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 19;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 19 - GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:1>DescriptionHelper:1>Description:0>#Other:0",
@@ -1678,7 +1988,10 @@ sub match_token_at_19 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:1>DescriptionHelper:2>#Comment:0
 sub match_token_at_20 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -1687,16 +2000,22 @@ sub match_token_at_20 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 20;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesTable');
         $self->_build($context, $token);
         return 21;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1706,7 +2025,9 @@ sub match_token_at_20 {
         return 17;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1718,7 +2039,9 @@ sub match_token_at_20 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -1729,7 +2052,9 @@ sub match_token_at_20 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -1737,7 +2062,9 @@ sub match_token_at_20 {
         $self->_build($context, $token);
         return 18;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -1747,7 +2074,9 @@ sub match_token_at_20 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -1757,13 +2086,15 @@ sub match_token_at_20 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 20;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Empty"],
         "State: 20 - GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:1>DescriptionHelper:2>#Comment:0",
@@ -1776,7 +2107,10 @@ sub match_token_at_20 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:2>ExamplesTable:0>#TableRow:0
 sub match_token_at_21 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1786,11 +2120,15 @@ sub match_token_at_21 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 21;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
@@ -1801,7 +2139,9 @@ sub match_token_at_21 {
         return 17;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
@@ -1814,7 +2154,9 @@ sub match_token_at_21 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1826,7 +2168,9 @@ sub match_token_at_21 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1835,7 +2179,9 @@ sub match_token_at_21 {
         $self->_build($context, $token);
         return 18;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1846,7 +2192,9 @@ sub match_token_at_21 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -1857,17 +2205,21 @@ sub match_token_at_21 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 21;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 21;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 21 - GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:2>ExamplesTable:0>#TableRow:0",
@@ -1880,26 +2232,35 @@ sub match_token_at_21 {
 # GherkinDocument:0>Feature:3>Rule:0>RuleHeader:0>Tags:0>#TagLine:0
 sub match_token_at_22 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_TagLine($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Tags');
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 22;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#TagLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 22 - GherkinDocument:0>Feature:3>Rule:0>RuleHeader:0>Tags:0>#TagLine:0",
@@ -1912,28 +2273,39 @@ sub match_token_at_22 {
 # GherkinDocument:0>Feature:3>Rule:0>RuleHeader:1>#RuleLine:0
 sub match_token_at_23 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
         $self->_end_rule($context, 'Rule');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 25;
     }
-    if ($self->match_BackgroundLine($context, $token)) {
+    ($ok, $err) = $self->match_BackgroundLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
         $self->_start_rule($context, 'Background');
         $self->_build($context, $token);
         return 26;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'RuleHeader');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -1942,7 +2314,9 @@ sub match_token_at_23 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
         $self->_end_rule($context, 'Rule');
         $self->_start_rule($context, 'Rule');
@@ -1951,14 +2325,18 @@ sub match_token_at_23 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
         $self->_start_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'Scenario');
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
         $self->_end_rule($context, 'Rule');
         $self->_start_rule($context, 'Rule');
@@ -1966,14 +2344,16 @@ sub match_token_at_23 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
         $self->_build($context, $token);
         return 24;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Empty", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 23 - GherkinDocument:0>Feature:3>Rule:0>RuleHeader:1>#RuleLine:0",
@@ -1986,7 +2366,10 @@ sub match_token_at_23 {
 # GherkinDocument:0>Feature:3>Rule:0>RuleHeader:2>DescriptionHelper:1>Description:0>#Other:0
 sub match_token_at_24 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'RuleHeader');
         $self->_end_rule($context, 'Rule');
@@ -1994,19 +2377,25 @@ sub match_token_at_24 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 25;
     }
-    if ($self->match_BackgroundLine($context, $token)) {
+    ($ok, $err) = $self->match_BackgroundLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'RuleHeader');
         $self->_start_rule($context, 'Background');
         $self->_build($context, $token);
         return 26;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'RuleHeader');
@@ -2016,7 +2405,9 @@ sub match_token_at_24 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'RuleHeader');
         $self->_end_rule($context, 'Rule');
@@ -2026,7 +2417,9 @@ sub match_token_at_24 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'RuleHeader');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -2034,7 +2427,9 @@ sub match_token_at_24 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'RuleHeader');
         $self->_end_rule($context, 'Rule');
@@ -2043,13 +2438,15 @@ sub match_token_at_24 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 24;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 24 - GherkinDocument:0>Feature:3>Rule:0>RuleHeader:2>DescriptionHelper:1>Description:0>#Other:0",
@@ -2062,24 +2459,33 @@ sub match_token_at_24 {
 # GherkinDocument:0>Feature:3>Rule:0>RuleHeader:2>DescriptionHelper:2>#Comment:0
 sub match_token_at_25 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
         $self->_end_rule($context, 'Rule');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 25;
     }
-    if ($self->match_BackgroundLine($context, $token)) {
+    ($ok, $err) = $self->match_BackgroundLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
         $self->_start_rule($context, 'Background');
         $self->_build($context, $token);
         return 26;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'RuleHeader');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -2088,7 +2494,9 @@ sub match_token_at_25 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
         $self->_end_rule($context, 'Rule');
         $self->_start_rule($context, 'Rule');
@@ -2097,14 +2505,18 @@ sub match_token_at_25 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
         $self->_start_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'Scenario');
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
         $self->_end_rule($context, 'Rule');
         $self->_start_rule($context, 'Rule');
@@ -2112,13 +2524,15 @@ sub match_token_at_25 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 25;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#BackgroundLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Empty"],
         "State: 25 - GherkinDocument:0>Feature:3>Rule:0>RuleHeader:2>DescriptionHelper:2>#Comment:0",
@@ -2131,27 +2545,38 @@ sub match_token_at_25 {
 # GherkinDocument:0>Feature:3>Rule:1>Background:0>#BackgroundLine:0
 sub match_token_at_26 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Rule');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 26;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 28;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 29;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -2160,7 +2585,9 @@ sub match_token_at_26 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Rule');
         $self->_start_rule($context, 'Rule');
@@ -2169,14 +2596,18 @@ sub match_token_at_26 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'Scenario');
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Rule');
         $self->_start_rule($context, 'Rule');
@@ -2184,14 +2615,16 @@ sub match_token_at_26 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
         $self->_build($context, $token);
         return 27;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Empty", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 26 - GherkinDocument:0>Feature:3>Rule:1>Background:0>#BackgroundLine:0",
@@ -2204,7 +2637,10 @@ sub match_token_at_26 {
 # GherkinDocument:0>Feature:3>Rule:1>Background:1>DescriptionHelper:1>Description:0>#Other:0
 sub match_token_at_27 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Rule');
@@ -2212,18 +2648,24 @@ sub match_token_at_27 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 28;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 29;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Background');
@@ -2233,7 +2675,9 @@ sub match_token_at_27 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Rule');
@@ -2243,7 +2687,9 @@ sub match_token_at_27 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -2251,7 +2697,9 @@ sub match_token_at_27 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Rule');
@@ -2260,13 +2708,15 @@ sub match_token_at_27 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 27;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 27 - GherkinDocument:0>Feature:3>Rule:1>Background:1>DescriptionHelper:1>Description:0>#Other:0",
@@ -2279,23 +2729,32 @@ sub match_token_at_27 {
 # GherkinDocument:0>Feature:3>Rule:1>Background:1>DescriptionHelper:2>#Comment:0
 sub match_token_at_28 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Rule');
         $self->_end_rule($context, 'Feature');
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 28;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 29;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -2304,7 +2763,9 @@ sub match_token_at_28 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Rule');
         $self->_start_rule($context, 'Rule');
@@ -2313,14 +2774,18 @@ sub match_token_at_28 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'Scenario');
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Rule');
         $self->_start_rule($context, 'Rule');
@@ -2328,13 +2793,15 @@ sub match_token_at_28 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 28;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Empty"],
         "State: 28 - GherkinDocument:0>Feature:3>Rule:1>Background:1>DescriptionHelper:2>#Comment:0",
@@ -2347,7 +2814,10 @@ sub match_token_at_28 {
 # GherkinDocument:0>Feature:3>Rule:1>Background:2>Step:0>#StepLine:0
 sub match_token_at_29 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Rule');
@@ -2355,23 +2825,31 @@ sub match_token_at_29 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DataTable');
         $self->_build($context, $token);
         return 30;
     }
-    if ($self->match_DocStringSeparator($context, $token)) {
+    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DocString');
         $self->_build($context, $token);
         return 45;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 29;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -2381,7 +2859,9 @@ sub match_token_at_29 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Rule');
@@ -2391,7 +2871,9 @@ sub match_token_at_29 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -2399,7 +2881,9 @@ sub match_token_at_29 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
         $self->_end_rule($context, 'Rule');
@@ -2408,17 +2892,21 @@ sub match_token_at_29 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 29;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 29;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 29 - GherkinDocument:0>Feature:3>Rule:1>Background:2>Step:0>#StepLine:0",
@@ -2431,7 +2919,10 @@ sub match_token_at_29 {
 # GherkinDocument:0>Feature:3>Rule:1>Background:2>Step:1>StepArg:0>__alt0:0>DataTable:0>#TableRow:0
 sub match_token_at_30 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -2440,18 +2931,24 @@ sub match_token_at_30 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 30;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 29;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
@@ -2462,7 +2959,9 @@ sub match_token_at_30 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -2473,7 +2972,9 @@ sub match_token_at_30 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -2482,7 +2983,9 @@ sub match_token_at_30 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -2492,17 +2995,21 @@ sub match_token_at_30 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 30;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 30;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#TableRow", "#StepLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 30 - GherkinDocument:0>Feature:3>Rule:1>Background:2>Step:1>StepArg:0>__alt0:0>DataTable:0>#TableRow:0",
@@ -2515,27 +3022,36 @@ sub match_token_at_30 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:0>Tags:0>#TagLine:0
 sub match_token_at_31 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_TagLine($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 31;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Tags');
         $self->_start_rule($context, 'Scenario');
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 31;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 31;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#TagLine", "#ScenarioLine", "#Comment", "#Empty"],
         "State: 31 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:0>Tags:0>#TagLine:0",
@@ -2548,7 +3064,10 @@ sub match_token_at_31 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:0>#ScenarioLine:0
 sub match_token_at_32 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_end_rule($context, 'Rule');
@@ -2556,20 +3075,28 @@ sub match_token_at_32 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 34;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 35;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_start_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'Tags');
@@ -2577,7 +3104,9 @@ sub match_token_at_32 {
         return 37;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -2587,7 +3116,9 @@ sub match_token_at_32 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_end_rule($context, 'Rule');
@@ -2597,13 +3128,17 @@ sub match_token_at_32 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'Examples');
         $self->_build($context, $token);
         return 38;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -2611,7 +3146,9 @@ sub match_token_at_32 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_end_rule($context, 'Rule');
@@ -2620,14 +3157,16 @@ sub match_token_at_32 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
         $self->_build($context, $token);
         return 33;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Empty", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 32 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:0>#ScenarioLine:0",
@@ -2640,7 +3179,10 @@ sub match_token_at_32 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:1>DescriptionHelper:1>Description:0>#Other:0
 sub match_token_at_33 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -2649,18 +3191,24 @@ sub match_token_at_33 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 34;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 35;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'Description');
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -2669,7 +3217,9 @@ sub match_token_at_33 {
         return 37;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Scenario');
@@ -2680,7 +3230,9 @@ sub match_token_at_33 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -2691,14 +3243,18 @@ sub match_token_at_33 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_start_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'Examples');
         $self->_build($context, $token);
         return 38;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -2707,7 +3263,9 @@ sub match_token_at_33 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -2717,13 +3275,15 @@ sub match_token_at_33 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 33;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 33 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:1>DescriptionHelper:1>Description:0>#Other:0",
@@ -2736,7 +3296,10 @@ sub match_token_at_33 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:1>DescriptionHelper:2>#Comment:0
 sub match_token_at_34 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_end_rule($context, 'Rule');
@@ -2744,16 +3307,22 @@ sub match_token_at_34 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 34;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 35;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_start_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'Tags');
@@ -2761,7 +3330,9 @@ sub match_token_at_34 {
         return 37;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -2771,7 +3342,9 @@ sub match_token_at_34 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_end_rule($context, 'Rule');
@@ -2781,13 +3354,17 @@ sub match_token_at_34 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'Examples');
         $self->_build($context, $token);
         return 38;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_start_rule($context, 'ScenarioDefinition');
@@ -2795,7 +3372,9 @@ sub match_token_at_34 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
         $self->_end_rule($context, 'Rule');
@@ -2804,13 +3383,15 @@ sub match_token_at_34 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 34;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Empty"],
         "State: 34 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:1>DescriptionHelper:2>#Comment:0",
@@ -2823,7 +3404,10 @@ sub match_token_at_34 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:2>Step:0>#StepLine:0
 sub match_token_at_35 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -2832,23 +3416,31 @@ sub match_token_at_35 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DataTable');
         $self->_build($context, $token);
         return 36;
     }
-    if ($self->match_DocStringSeparator($context, $token)) {
+    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DocString');
         $self->_build($context, $token);
         return 43;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 35;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -2857,7 +3449,9 @@ sub match_token_at_35 {
         return 37;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -2868,7 +3462,9 @@ sub match_token_at_35 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -2879,14 +3475,18 @@ sub match_token_at_35 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'Examples');
         $self->_build($context, $token);
         return 38;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -2895,7 +3495,9 @@ sub match_token_at_35 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
         $self->_end_rule($context, 'ScenarioDefinition');
@@ -2905,17 +3507,21 @@ sub match_token_at_35 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 35;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 35;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#TableRow", "#DocStringSeparator", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 35 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:2>Step:0>#StepLine:0",
@@ -2928,7 +3534,10 @@ sub match_token_at_35 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:2>Step:1>StepArg:0>__alt0:0>DataTable:0>#TableRow:0
 sub match_token_at_36 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -2938,18 +3547,24 @@ sub match_token_at_36 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 36;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 35;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
@@ -2959,7 +3574,9 @@ sub match_token_at_36 {
         return 37;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
@@ -2971,7 +3588,9 @@ sub match_token_at_36 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -2983,7 +3602,9 @@ sub match_token_at_36 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -2991,7 +3612,9 @@ sub match_token_at_36 {
         $self->_build($context, $token);
         return 38;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -3001,7 +3624,9 @@ sub match_token_at_36 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -3012,17 +3637,21 @@ sub match_token_at_36 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 36;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 36;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#TableRow", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 36 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:2>Step:1>StepArg:0>__alt0:0>DataTable:0>#TableRow:0",
@@ -3035,27 +3664,36 @@ sub match_token_at_36 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:0>Tags:0>#TagLine:0
 sub match_token_at_37 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_TagLine($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 37;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Tags');
         $self->_start_rule($context, 'Examples');
         $self->_build($context, $token);
         return 38;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 37;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 37;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#TagLine", "#ExamplesLine", "#Comment", "#Empty"],
         "State: 37 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:0>Tags:0>#TagLine:0",
@@ -3068,7 +3706,10 @@ sub match_token_at_37 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:0>#ExamplesLine:0
 sub match_token_at_38 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -3078,20 +3719,28 @@ sub match_token_at_38 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 38;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 40;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesTable');
         $self->_build($context, $token);
         return 41;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3101,7 +3750,9 @@ sub match_token_at_38 {
         return 37;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3113,7 +3764,9 @@ sub match_token_at_38 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -3125,7 +3778,9 @@ sub match_token_at_38 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -3133,7 +3788,9 @@ sub match_token_at_38 {
         $self->_build($context, $token);
         return 38;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -3143,7 +3800,9 @@ sub match_token_at_38 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -3154,14 +3813,16 @@ sub match_token_at_38 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
         $self->_build($context, $token);
         return 39;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Empty", "#Comment", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 38 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:0>#ExamplesLine:0",
@@ -3174,7 +3835,10 @@ sub match_token_at_38 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:1>DescriptionHelper:1>Description:0>#Other:0
 sub match_token_at_39 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3185,18 +3849,24 @@ sub match_token_at_39 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 40;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_start_rule($context, 'ExamplesTable');
         $self->_build($context, $token);
         return 41;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
@@ -3207,7 +3877,9 @@ sub match_token_at_39 {
         return 37;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
@@ -3220,7 +3892,9 @@ sub match_token_at_39 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3233,7 +3907,9 @@ sub match_token_at_39 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3242,7 +3918,9 @@ sub match_token_at_39 {
         $self->_build($context, $token);
         return 38;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3253,7 +3931,9 @@ sub match_token_at_39 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3265,13 +3945,15 @@ sub match_token_at_39 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 39;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Other"],
         "State: 39 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:1>DescriptionHelper:1>Description:0>#Other:0",
@@ -3284,7 +3966,10 @@ sub match_token_at_39 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:1>DescriptionHelper:2>#Comment:0
 sub match_token_at_40 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -3294,16 +3979,22 @@ sub match_token_at_40 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 40;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesTable');
         $self->_build($context, $token);
         return 41;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3313,7 +4004,9 @@ sub match_token_at_40 {
         return 37;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3325,7 +4018,9 @@ sub match_token_at_40 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -3337,7 +4032,9 @@ sub match_token_at_40 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -3345,7 +4042,9 @@ sub match_token_at_40 {
         $self->_build($context, $token);
         return 38;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -3355,7 +4054,9 @@ sub match_token_at_40 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
         $self->_end_rule($context, 'Scenario');
@@ -3366,13 +4067,15 @@ sub match_token_at_40 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 40;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#Comment", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Empty"],
         "State: 40 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:1>DescriptionHelper:2>#Comment:0",
@@ -3385,7 +4088,10 @@ sub match_token_at_40 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:2>ExamplesTable:0>#TableRow:0
 sub match_token_at_41 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3396,11 +4102,15 @@ sub match_token_at_41 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_TableRow($context, $token)) {
+    ($ok, $err) = $self->match_TableRow($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 41;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
@@ -3411,7 +4121,9 @@ sub match_token_at_41 {
         return 37;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
@@ -3424,7 +4136,9 @@ sub match_token_at_41 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3437,7 +4151,9 @@ sub match_token_at_41 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3446,7 +4162,9 @@ sub match_token_at_41 {
         $self->_build($context, $token);
         return 38;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3457,7 +4175,9 @@ sub match_token_at_41 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
         $self->_end_rule($context, 'Examples');
         $self->_end_rule($context, 'ExamplesDefinition');
@@ -3469,17 +4189,21 @@ sub match_token_at_41 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 41;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 41;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#TableRow", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 41 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:3>ExamplesDefinition:1>Examples:2>ExamplesTable:0>#TableRow:0",
@@ -3492,17 +4216,22 @@ sub match_token_at_41 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:2>Step:1>StepArg:0>__alt0:1>DocString:0>#DocStringSeparator:0
 sub match_token_at_43 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_DocStringSeparator($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 44;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 43;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#DocStringSeparator", "#Other"],
         "State: 43 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:2>Step:1>StepArg:0>__alt0:1>DocString:0>#DocStringSeparator:0",
@@ -3515,7 +4244,10 @@ sub match_token_at_43 {
 # GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:2>Step:1>StepArg:0>__alt0:1>DocString:2>#DocStringSeparator:0
 sub match_token_at_44 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -3525,14 +4257,18 @@ sub match_token_at_44 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 35;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
@@ -3542,7 +4278,9 @@ sub match_token_at_44 {
         return 37;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
@@ -3554,7 +4292,9 @@ sub match_token_at_44 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -3566,7 +4306,9 @@ sub match_token_at_44 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -3574,7 +4316,9 @@ sub match_token_at_44 {
         $self->_build($context, $token);
         return 38;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -3584,7 +4328,9 @@ sub match_token_at_44 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -3595,17 +4341,21 @@ sub match_token_at_44 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 44;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 44;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 44 - GherkinDocument:0>Feature:3>Rule:2>ScenarioDefinition:1>Scenario:2>Step:1>StepArg:0>__alt0:1>DocString:2>#DocStringSeparator:0",
@@ -3618,17 +4368,22 @@ sub match_token_at_44 {
 # GherkinDocument:0>Feature:3>Rule:1>Background:2>Step:1>StepArg:0>__alt0:1>DocString:0>#DocStringSeparator:0
 sub match_token_at_45 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_DocStringSeparator($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 46;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 45;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#DocStringSeparator", "#Other"],
         "State: 45 - GherkinDocument:0>Feature:3>Rule:1>Background:2>Step:1>StepArg:0>__alt0:1>DocString:0>#DocStringSeparator:0",
@@ -3641,7 +4396,10 @@ sub match_token_at_45 {
 # GherkinDocument:0>Feature:3>Rule:1>Background:2>Step:1>StepArg:0>__alt0:1>DocString:2>#DocStringSeparator:0
 sub match_token_at_46 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -3650,14 +4408,18 @@ sub match_token_at_46 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 29;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
@@ -3668,7 +4430,9 @@ sub match_token_at_46 {
         return 31;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -3679,7 +4443,9 @@ sub match_token_at_46 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -3688,7 +4454,9 @@ sub match_token_at_46 {
         $self->_build($context, $token);
         return 32;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -3698,17 +4466,21 @@ sub match_token_at_46 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 46;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 46;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#StepLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 46 - GherkinDocument:0>Feature:3>Rule:1>Background:2>Step:1>StepArg:0>__alt0:1>DocString:2>#DocStringSeparator:0",
@@ -3721,17 +4493,22 @@ sub match_token_at_46 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:2>Step:1>StepArg:0>__alt0:1>DocString:0>#DocStringSeparator:0
 sub match_token_at_47 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_DocStringSeparator($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 48;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 47;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#DocStringSeparator", "#Other"],
         "State: 47 - GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:2>Step:1>StepArg:0>__alt0:1>DocString:0>#DocStringSeparator:0",
@@ -3744,7 +4521,10 @@ sub match_token_at_47 {
 # GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:2>Step:1>StepArg:0>__alt0:1>DocString:2>#DocStringSeparator:0
 sub match_token_at_48 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -3753,14 +4533,18 @@ sub match_token_at_48 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 15;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
@@ -3770,7 +4554,9 @@ sub match_token_at_48 {
         return 17;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
@@ -3782,7 +4568,9 @@ sub match_token_at_48 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -3793,7 +4581,9 @@ sub match_token_at_48 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ExamplesLine($context, $token)) {
+    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -3801,7 +4591,9 @@ sub match_token_at_48 {
         $self->_build($context, $token);
         return 18;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -3811,7 +4603,9 @@ sub match_token_at_48 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Scenario');
@@ -3821,17 +4615,21 @@ sub match_token_at_48 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 48;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 48;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#StepLine", "#TagLine", "#ExamplesLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 48 - GherkinDocument:0>Feature:2>ScenarioDefinition:1>Scenario:2>Step:1>StepArg:0>__alt0:1>DocString:2>#DocStringSeparator:0",
@@ -3844,17 +4642,22 @@ sub match_token_at_48 {
 # GherkinDocument:0>Feature:1>Background:2>Step:1>StepArg:0>__alt0:1>DocString:0>#DocStringSeparator:0
 sub match_token_at_49 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_DocStringSeparator($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 50;
     }
-    if ($self->match_Other($context, $token)) {
+    ($ok, $err) = $self->match_Other($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 49;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#DocStringSeparator", "#Other"],
         "State: 49 - GherkinDocument:0>Feature:1>Background:2>Step:1>StepArg:0>__alt0:1>DocString:0>#DocStringSeparator:0",
@@ -3867,7 +4670,10 @@ sub match_token_at_49 {
 # GherkinDocument:0>Feature:1>Background:2>Step:1>StepArg:0>__alt0:1>DocString:2>#DocStringSeparator:0
 sub match_token_at_50 {
     my ( $self, $token, $context ) = @_;
-    if ($self->match_EOF($context, $token)) {
+    my ( $ok, $err );
+    ($ok, $err) = $self->match_EOF($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -3875,14 +4681,18 @@ sub match_token_at_50 {
         $self->_build($context, $token);
         return 42;
     }
-    if ($self->match_StepLine($context, $token)) {
+    ($ok, $err) = $self->match_StepLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 9;
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
@@ -3893,7 +4703,9 @@ sub match_token_at_50 {
         return 11;
         }
     }
-    if ($self->match_TagLine($context, $token)) {
+    ($ok, $err) = $self->match_TagLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -3903,7 +4715,9 @@ sub match_token_at_50 {
         $self->_build($context, $token);
         return 22;
     }
-    if ($self->match_ScenarioLine($context, $token)) {
+    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -3912,7 +4726,9 @@ sub match_token_at_50 {
         $self->_build($context, $token);
         return 12;
     }
-    if ($self->match_RuleLine($context, $token)) {
+    ($ok, $err) = $self->match_RuleLine($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
         $self->_end_rule($context, 'Step');
         $self->_end_rule($context, 'Background');
@@ -3921,17 +4737,21 @@ sub match_token_at_50 {
         $self->_build($context, $token);
         return 23;
     }
-    if ($self->match_Comment($context, $token)) {
+    ($ok, $err) = $self->match_Comment($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 50;
     }
-    if ($self->match_Empty($context, $token)) {
+    ($ok, $err) = $self->match_Empty($context, $token);
+    if ($ok) {
+        $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 50;
     }
 
     $token->detach;
-    my $err = $self->_construct_parser_error(
+    $err = $self->_construct_parser_error(
         $token,
         ["#EOF", "#StepLine", "#TagLine", "#ScenarioLine", "#RuleLine", "#Comment", "#Empty"],
         "State: 50 - GherkinDocument:0>Feature:1>Background:2>Step:1>StepArg:0>__alt0:1>DocString:2>#DocStringSeparator:0",
@@ -3951,18 +4771,22 @@ sub lookahead_0 {
     my @queue;
     my $match = 0;
 
+    my $ok;
     while (1) {
         $token = $context->read_token();
         $token->detach;
         push( @queue, $token );
 
-        $match = 1 if $self->match_ScenarioLine($context, $token);
+
+        ($match) = $self->match_ScenarioLine($context, $token);
         last if $match;
 
-        next if $self->match_Empty($context, $token);
-        next if $self->match_Comment($context, $token);
-        next if $self->match_TagLine($context, $token);
-
+        ($ok) = $self->match_Empty($context, $token);
+        next if $ok;
+        ($ok) = $self->match_Comment($context, $token);
+        next if $ok;
+        ($ok) = $self->match_TagLine($context, $token);
+        next if $ok;
         last;
     }
 
@@ -3978,18 +4802,22 @@ sub lookahead_1 {
     my @queue;
     my $match = 0;
 
+    my $ok;
     while (1) {
         $token = $context->read_token();
         $token->detach;
         push( @queue, $token );
 
-        $match = 1 if $self->match_ExamplesLine($context, $token);
+
+        ($match) = $self->match_ExamplesLine($context, $token);
         last if $match;
 
-        next if $self->match_Empty($context, $token);
-        next if $self->match_Comment($context, $token);
-        next if $self->match_TagLine($context, $token);
-
+        ($ok) = $self->match_Empty($context, $token);
+        next if $ok;
+        ($ok) = $self->match_Comment($context, $token);
+        next if $ok;
+        ($ok) = $self->match_TagLine($context, $token);
+        next if $ok;
         last;
     }
 

--- a/perl/lib/Gherkin/Generated/Parser.pm
+++ b/perl/lib/Gherkin/Generated/Parser.pm
@@ -112,101 +112,17 @@ sub _construct_parser_error {
 }
 
 
-sub match_EOF {
-    my ($self, $context, $token) = @_;
-    $context->token_matcher->match_EOF( $token );
-}
-
-sub match_Empty {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_Empty( $token );
-}
-
-sub match_Comment {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_Comment( $token );
-}
-
-sub match_TagLine {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_TagLine( $token );
-}
-
-sub match_FeatureLine {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_FeatureLine( $token );
-}
-
-sub match_RuleLine {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_RuleLine( $token );
-}
-
-sub match_BackgroundLine {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_BackgroundLine( $token );
-}
-
-sub match_ScenarioLine {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_ScenarioLine( $token );
-}
-
-sub match_ExamplesLine {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_ExamplesLine( $token );
-}
-
-sub match_StepLine {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_StepLine( $token );
-}
-
-sub match_DocStringSeparator {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_DocStringSeparator( $token );
-}
-
-sub match_TableRow {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_TableRow( $token );
-}
-
-sub match_Language {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_Language( $token );
-}
-
-sub match_Other {
-    my ($self, $context, $token) = @_;
-    return if $token->is_eof;
-    $context->token_matcher->match_Other( $token );
-}
-
-
 # Start
 sub match_token_at_0 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Language($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Language($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Feature');
@@ -214,7 +130,7 @@ sub match_token_at_0 {
         $self->_build($context, $token);
         return 1;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Feature');
@@ -223,7 +139,7 @@ sub match_token_at_0 {
         $self->_build($context, $token);
         return 2;
     }
-    ($ok, $err) = $self->match_FeatureLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_FeatureLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Feature');
@@ -231,13 +147,13 @@ sub match_token_at_0 {
         $self->_build($context, $token);
         return 3;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 0;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -259,26 +175,26 @@ sub match_token_at_0 {
 sub match_token_at_1 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Tags');
         $self->_build($context, $token);
         return 2;
     }
-    ($ok, $err) = $self->match_FeatureLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_FeatureLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 3;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 1;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -300,26 +216,26 @@ sub match_token_at_1 {
 sub match_token_at_2 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 2;
     }
-    ($ok, $err) = $self->match_FeatureLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_FeatureLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Tags');
         $self->_build($context, $token);
         return 3;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 2;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -341,7 +257,7 @@ sub match_token_at_2 {
 sub match_token_at_3 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
@@ -349,19 +265,19 @@ sub match_token_at_3 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 3;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 5;
     }
-    ($ok, $err) = $self->match_BackgroundLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_BackgroundLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
@@ -369,7 +285,7 @@ sub match_token_at_3 {
         $self->_build($context, $token);
         return 6;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -380,7 +296,7 @@ sub match_token_at_3 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
@@ -390,7 +306,7 @@ sub match_token_at_3 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
@@ -399,7 +315,7 @@ sub match_token_at_3 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
@@ -408,7 +324,7 @@ sub match_token_at_3 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
@@ -431,7 +347,7 @@ sub match_token_at_3 {
 sub match_token_at_4 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -440,14 +356,14 @@ sub match_token_at_4 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 5;
     }
-    ($ok, $err) = $self->match_BackgroundLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_BackgroundLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -456,7 +372,7 @@ sub match_token_at_4 {
         $self->_build($context, $token);
         return 6;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -468,7 +384,7 @@ sub match_token_at_4 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -479,7 +395,7 @@ sub match_token_at_4 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -489,7 +405,7 @@ sub match_token_at_4 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -499,7 +415,7 @@ sub match_token_at_4 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -521,7 +437,7 @@ sub match_token_at_4 {
 sub match_token_at_5 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
@@ -529,13 +445,13 @@ sub match_token_at_5 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 5;
     }
-    ($ok, $err) = $self->match_BackgroundLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_BackgroundLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
@@ -543,7 +459,7 @@ sub match_token_at_5 {
         $self->_build($context, $token);
         return 6;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -554,7 +470,7 @@ sub match_token_at_5 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
@@ -564,7 +480,7 @@ sub match_token_at_5 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
@@ -573,7 +489,7 @@ sub match_token_at_5 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'FeatureHeader');
@@ -582,7 +498,7 @@ sub match_token_at_5 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -604,7 +520,7 @@ sub match_token_at_5 {
 sub match_token_at_6 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -612,26 +528,26 @@ sub match_token_at_6 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 6;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 8;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 9;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -642,7 +558,7 @@ sub match_token_at_6 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -652,7 +568,7 @@ sub match_token_at_6 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -661,7 +577,7 @@ sub match_token_at_6 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -670,7 +586,7 @@ sub match_token_at_6 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
@@ -693,7 +609,7 @@ sub match_token_at_6 {
 sub match_token_at_7 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -702,14 +618,14 @@ sub match_token_at_7 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 8;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -717,7 +633,7 @@ sub match_token_at_7 {
         $self->_build($context, $token);
         return 9;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -729,7 +645,7 @@ sub match_token_at_7 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -740,7 +656,7 @@ sub match_token_at_7 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -750,7 +666,7 @@ sub match_token_at_7 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -760,7 +676,7 @@ sub match_token_at_7 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -782,7 +698,7 @@ sub match_token_at_7 {
 sub match_token_at_8 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -790,20 +706,20 @@ sub match_token_at_8 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 8;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 9;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -814,7 +730,7 @@ sub match_token_at_8 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -824,7 +740,7 @@ sub match_token_at_8 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -833,7 +749,7 @@ sub match_token_at_8 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -842,7 +758,7 @@ sub match_token_at_8 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -864,7 +780,7 @@ sub match_token_at_8 {
 sub match_token_at_9 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -873,21 +789,21 @@ sub match_token_at_9 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DataTable');
         $self->_build($context, $token);
         return 10;
     }
-    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    ($ok, $err) = $context->token_matcher->match_DocStringSeparator($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DocString');
         $self->_build($context, $token);
         return 49;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -895,7 +811,7 @@ sub match_token_at_9 {
         $self->_build($context, $token);
         return 9;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -907,7 +823,7 @@ sub match_token_at_9 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -918,7 +834,7 @@ sub match_token_at_9 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -928,7 +844,7 @@ sub match_token_at_9 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -938,13 +854,13 @@ sub match_token_at_9 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 9;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -966,7 +882,7 @@ sub match_token_at_9 {
 sub match_token_at_10 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -976,13 +892,13 @@ sub match_token_at_10 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 10;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -991,7 +907,7 @@ sub match_token_at_10 {
         $self->_build($context, $token);
         return 9;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -1004,7 +920,7 @@ sub match_token_at_10 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -1016,7 +932,7 @@ sub match_token_at_10 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -1027,7 +943,7 @@ sub match_token_at_10 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -1038,13 +954,13 @@ sub match_token_at_10 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 10;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -1066,13 +982,13 @@ sub match_token_at_10 {
 sub match_token_at_11 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 11;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Tags');
@@ -1080,13 +996,13 @@ sub match_token_at_11 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 11;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -1108,7 +1024,7 @@ sub match_token_at_11 {
 sub match_token_at_12 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -1117,26 +1033,26 @@ sub match_token_at_12 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 14;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 15;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -1146,7 +1062,7 @@ sub match_token_at_12 {
         return 17;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -1158,7 +1074,7 @@ sub match_token_at_12 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -1169,7 +1085,7 @@ sub match_token_at_12 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -1177,7 +1093,7 @@ sub match_token_at_12 {
         $self->_build($context, $token);
         return 18;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -1187,7 +1103,7 @@ sub match_token_at_12 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -1197,7 +1113,7 @@ sub match_token_at_12 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
@@ -1220,7 +1136,7 @@ sub match_token_at_12 {
 sub match_token_at_13 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -1230,14 +1146,14 @@ sub match_token_at_13 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 14;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -1245,7 +1161,7 @@ sub match_token_at_13 {
         $self->_build($context, $token);
         return 15;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -1256,7 +1172,7 @@ sub match_token_at_13 {
         return 17;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -1269,7 +1185,7 @@ sub match_token_at_13 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -1281,7 +1197,7 @@ sub match_token_at_13 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -1290,7 +1206,7 @@ sub match_token_at_13 {
         $self->_build($context, $token);
         return 18;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -1301,7 +1217,7 @@ sub match_token_at_13 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -1312,7 +1228,7 @@ sub match_token_at_13 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -1334,7 +1250,7 @@ sub match_token_at_13 {
 sub match_token_at_14 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -1343,20 +1259,20 @@ sub match_token_at_14 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 14;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 15;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -1366,7 +1282,7 @@ sub match_token_at_14 {
         return 17;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -1378,7 +1294,7 @@ sub match_token_at_14 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -1389,7 +1305,7 @@ sub match_token_at_14 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -1397,7 +1313,7 @@ sub match_token_at_14 {
         $self->_build($context, $token);
         return 18;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -1407,7 +1323,7 @@ sub match_token_at_14 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -1417,7 +1333,7 @@ sub match_token_at_14 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -1439,7 +1355,7 @@ sub match_token_at_14 {
 sub match_token_at_15 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -1449,21 +1365,21 @@ sub match_token_at_15 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DataTable');
         $self->_build($context, $token);
         return 16;
     }
-    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    ($ok, $err) = $context->token_matcher->match_DocStringSeparator($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DocString');
         $self->_build($context, $token);
         return 47;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -1471,7 +1387,7 @@ sub match_token_at_15 {
         $self->_build($context, $token);
         return 15;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -1482,7 +1398,7 @@ sub match_token_at_15 {
         return 17;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -1495,7 +1411,7 @@ sub match_token_at_15 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -1507,7 +1423,7 @@ sub match_token_at_15 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -1516,7 +1432,7 @@ sub match_token_at_15 {
         $self->_build($context, $token);
         return 18;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -1527,7 +1443,7 @@ sub match_token_at_15 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -1538,13 +1454,13 @@ sub match_token_at_15 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 15;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -1566,7 +1482,7 @@ sub match_token_at_15 {
 sub match_token_at_16 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -1577,13 +1493,13 @@ sub match_token_at_16 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 16;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -1592,7 +1508,7 @@ sub match_token_at_16 {
         $self->_build($context, $token);
         return 15;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -1604,7 +1520,7 @@ sub match_token_at_16 {
         return 17;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -1618,7 +1534,7 @@ sub match_token_at_16 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -1631,7 +1547,7 @@ sub match_token_at_16 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -1641,7 +1557,7 @@ sub match_token_at_16 {
         $self->_build($context, $token);
         return 18;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -1653,7 +1569,7 @@ sub match_token_at_16 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -1665,13 +1581,13 @@ sub match_token_at_16 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 16;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -1693,13 +1609,13 @@ sub match_token_at_16 {
 sub match_token_at_17 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 17;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Tags');
@@ -1707,13 +1623,13 @@ sub match_token_at_17 {
         $self->_build($context, $token);
         return 18;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 17;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -1735,7 +1651,7 @@ sub match_token_at_17 {
 sub match_token_at_18 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -1746,26 +1662,26 @@ sub match_token_at_18 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 18;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 20;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesTable');
         $self->_build($context, $token);
         return 21;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -1777,7 +1693,7 @@ sub match_token_at_18 {
         return 17;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -1791,7 +1707,7 @@ sub match_token_at_18 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -1804,7 +1720,7 @@ sub match_token_at_18 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -1814,7 +1730,7 @@ sub match_token_at_18 {
         $self->_build($context, $token);
         return 18;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -1826,7 +1742,7 @@ sub match_token_at_18 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -1838,7 +1754,7 @@ sub match_token_at_18 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
@@ -1861,7 +1777,7 @@ sub match_token_at_18 {
 sub match_token_at_19 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -1873,14 +1789,14 @@ sub match_token_at_19 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 20;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -1888,7 +1804,7 @@ sub match_token_at_19 {
         $self->_build($context, $token);
         return 21;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -1901,7 +1817,7 @@ sub match_token_at_19 {
         return 17;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -1916,7 +1832,7 @@ sub match_token_at_19 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -1930,7 +1846,7 @@ sub match_token_at_19 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -1941,7 +1857,7 @@ sub match_token_at_19 {
         $self->_build($context, $token);
         return 18;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -1954,7 +1870,7 @@ sub match_token_at_19 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -1967,7 +1883,7 @@ sub match_token_at_19 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -1989,7 +1905,7 @@ sub match_token_at_19 {
 sub match_token_at_20 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -2000,20 +1916,20 @@ sub match_token_at_20 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 20;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesTable');
         $self->_build($context, $token);
         return 21;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -2025,7 +1941,7 @@ sub match_token_at_20 {
         return 17;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -2039,7 +1955,7 @@ sub match_token_at_20 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -2052,7 +1968,7 @@ sub match_token_at_20 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -2062,7 +1978,7 @@ sub match_token_at_20 {
         $self->_build($context, $token);
         return 18;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -2074,7 +1990,7 @@ sub match_token_at_20 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -2086,7 +2002,7 @@ sub match_token_at_20 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -2108,7 +2024,7 @@ sub match_token_at_20 {
 sub match_token_at_21 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
@@ -2120,13 +2036,13 @@ sub match_token_at_21 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 21;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -2139,7 +2055,7 @@ sub match_token_at_21 {
         return 17;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -2154,7 +2070,7 @@ sub match_token_at_21 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
@@ -2168,7 +2084,7 @@ sub match_token_at_21 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
@@ -2179,7 +2095,7 @@ sub match_token_at_21 {
         $self->_build($context, $token);
         return 18;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
@@ -2192,7 +2108,7 @@ sub match_token_at_21 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
@@ -2205,13 +2121,13 @@ sub match_token_at_21 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 21;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -2233,26 +2149,26 @@ sub match_token_at_21 {
 sub match_token_at_22 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Tags');
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -2274,7 +2190,7 @@ sub match_token_at_22 {
 sub match_token_at_23 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
@@ -2283,19 +2199,19 @@ sub match_token_at_23 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 25;
     }
-    ($ok, $err) = $self->match_BackgroundLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_BackgroundLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
@@ -2303,7 +2219,7 @@ sub match_token_at_23 {
         $self->_build($context, $token);
         return 26;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -2314,7 +2230,7 @@ sub match_token_at_23 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
@@ -2325,7 +2241,7 @@ sub match_token_at_23 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
@@ -2334,7 +2250,7 @@ sub match_token_at_23 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
@@ -2344,7 +2260,7 @@ sub match_token_at_23 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
@@ -2367,7 +2283,7 @@ sub match_token_at_23 {
 sub match_token_at_24 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -2377,14 +2293,14 @@ sub match_token_at_24 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 25;
     }
-    ($ok, $err) = $self->match_BackgroundLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_BackgroundLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -2393,7 +2309,7 @@ sub match_token_at_24 {
         $self->_build($context, $token);
         return 26;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -2405,7 +2321,7 @@ sub match_token_at_24 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -2417,7 +2333,7 @@ sub match_token_at_24 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -2427,7 +2343,7 @@ sub match_token_at_24 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -2438,7 +2354,7 @@ sub match_token_at_24 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -2460,7 +2376,7 @@ sub match_token_at_24 {
 sub match_token_at_25 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
@@ -2469,13 +2385,13 @@ sub match_token_at_25 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 25;
     }
-    ($ok, $err) = $self->match_BackgroundLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_BackgroundLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
@@ -2483,7 +2399,7 @@ sub match_token_at_25 {
         $self->_build($context, $token);
         return 26;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -2494,7 +2410,7 @@ sub match_token_at_25 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
@@ -2505,7 +2421,7 @@ sub match_token_at_25 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
@@ -2514,7 +2430,7 @@ sub match_token_at_25 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'RuleHeader');
@@ -2524,7 +2440,7 @@ sub match_token_at_25 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -2546,7 +2462,7 @@ sub match_token_at_25 {
 sub match_token_at_26 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -2555,26 +2471,26 @@ sub match_token_at_26 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 26;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 28;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 29;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -2585,7 +2501,7 @@ sub match_token_at_26 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -2596,7 +2512,7 @@ sub match_token_at_26 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -2605,7 +2521,7 @@ sub match_token_at_26 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -2615,7 +2531,7 @@ sub match_token_at_26 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
@@ -2638,7 +2554,7 @@ sub match_token_at_26 {
 sub match_token_at_27 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -2648,14 +2564,14 @@ sub match_token_at_27 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 28;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -2663,7 +2579,7 @@ sub match_token_at_27 {
         $self->_build($context, $token);
         return 29;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -2675,7 +2591,7 @@ sub match_token_at_27 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -2687,7 +2603,7 @@ sub match_token_at_27 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -2697,7 +2613,7 @@ sub match_token_at_27 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -2708,7 +2624,7 @@ sub match_token_at_27 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -2730,7 +2646,7 @@ sub match_token_at_27 {
 sub match_token_at_28 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -2739,20 +2655,20 @@ sub match_token_at_28 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 28;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 29;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -2763,7 +2679,7 @@ sub match_token_at_28 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -2774,7 +2690,7 @@ sub match_token_at_28 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -2783,7 +2699,7 @@ sub match_token_at_28 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Background');
@@ -2793,7 +2709,7 @@ sub match_token_at_28 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -2815,7 +2731,7 @@ sub match_token_at_28 {
 sub match_token_at_29 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -2825,21 +2741,21 @@ sub match_token_at_29 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DataTable');
         $self->_build($context, $token);
         return 30;
     }
-    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    ($ok, $err) = $context->token_matcher->match_DocStringSeparator($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DocString');
         $self->_build($context, $token);
         return 45;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -2847,7 +2763,7 @@ sub match_token_at_29 {
         $self->_build($context, $token);
         return 29;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -2859,7 +2775,7 @@ sub match_token_at_29 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -2871,7 +2787,7 @@ sub match_token_at_29 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -2881,7 +2797,7 @@ sub match_token_at_29 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -2892,13 +2808,13 @@ sub match_token_at_29 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 29;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -2920,7 +2836,7 @@ sub match_token_at_29 {
 sub match_token_at_30 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -2931,13 +2847,13 @@ sub match_token_at_30 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 30;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -2946,7 +2862,7 @@ sub match_token_at_30 {
         $self->_build($context, $token);
         return 29;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -2959,7 +2875,7 @@ sub match_token_at_30 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -2972,7 +2888,7 @@ sub match_token_at_30 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -2983,7 +2899,7 @@ sub match_token_at_30 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -2995,13 +2911,13 @@ sub match_token_at_30 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 30;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -3023,13 +2939,13 @@ sub match_token_at_30 {
 sub match_token_at_31 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 31;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Tags');
@@ -3037,13 +2953,13 @@ sub match_token_at_31 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 31;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -3065,7 +2981,7 @@ sub match_token_at_31 {
 sub match_token_at_32 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -3075,26 +2991,26 @@ sub match_token_at_32 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 34;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 35;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -3104,7 +3020,7 @@ sub match_token_at_32 {
         return 37;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -3116,7 +3032,7 @@ sub match_token_at_32 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -3128,7 +3044,7 @@ sub match_token_at_32 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -3136,7 +3052,7 @@ sub match_token_at_32 {
         $self->_build($context, $token);
         return 38;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -3146,7 +3062,7 @@ sub match_token_at_32 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -3157,7 +3073,7 @@ sub match_token_at_32 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
@@ -3180,7 +3096,7 @@ sub match_token_at_32 {
 sub match_token_at_33 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -3191,14 +3107,14 @@ sub match_token_at_33 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 34;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -3206,7 +3122,7 @@ sub match_token_at_33 {
         $self->_build($context, $token);
         return 35;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -3217,7 +3133,7 @@ sub match_token_at_33 {
         return 37;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -3230,7 +3146,7 @@ sub match_token_at_33 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -3243,7 +3159,7 @@ sub match_token_at_33 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -3252,7 +3168,7 @@ sub match_token_at_33 {
         $self->_build($context, $token);
         return 38;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -3263,7 +3179,7 @@ sub match_token_at_33 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -3275,7 +3191,7 @@ sub match_token_at_33 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -3297,7 +3213,7 @@ sub match_token_at_33 {
 sub match_token_at_34 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -3307,20 +3223,20 @@ sub match_token_at_34 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 34;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Step');
         $self->_build($context, $token);
         return 35;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -3330,7 +3246,7 @@ sub match_token_at_34 {
         return 37;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -3342,7 +3258,7 @@ sub match_token_at_34 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -3354,7 +3270,7 @@ sub match_token_at_34 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesDefinition');
@@ -3362,7 +3278,7 @@ sub match_token_at_34 {
         $self->_build($context, $token);
         return 38;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -3372,7 +3288,7 @@ sub match_token_at_34 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Scenario');
@@ -3383,7 +3299,7 @@ sub match_token_at_34 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -3405,7 +3321,7 @@ sub match_token_at_34 {
 sub match_token_at_35 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -3416,21 +3332,21 @@ sub match_token_at_35 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DataTable');
         $self->_build($context, $token);
         return 36;
     }
-    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    ($ok, $err) = $context->token_matcher->match_DocStringSeparator($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'DocString');
         $self->_build($context, $token);
         return 43;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -3438,7 +3354,7 @@ sub match_token_at_35 {
         $self->_build($context, $token);
         return 35;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -3449,7 +3365,7 @@ sub match_token_at_35 {
         return 37;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -3462,7 +3378,7 @@ sub match_token_at_35 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -3475,7 +3391,7 @@ sub match_token_at_35 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -3484,7 +3400,7 @@ sub match_token_at_35 {
         $self->_build($context, $token);
         return 38;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -3495,7 +3411,7 @@ sub match_token_at_35 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Step');
@@ -3507,13 +3423,13 @@ sub match_token_at_35 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 35;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -3535,7 +3451,7 @@ sub match_token_at_35 {
 sub match_token_at_36 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -3547,13 +3463,13 @@ sub match_token_at_36 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 36;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -3562,7 +3478,7 @@ sub match_token_at_36 {
         $self->_build($context, $token);
         return 35;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -3574,7 +3490,7 @@ sub match_token_at_36 {
         return 37;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -3588,7 +3504,7 @@ sub match_token_at_36 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -3602,7 +3518,7 @@ sub match_token_at_36 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -3612,7 +3528,7 @@ sub match_token_at_36 {
         $self->_build($context, $token);
         return 38;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -3624,7 +3540,7 @@ sub match_token_at_36 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DataTable');
@@ -3637,13 +3553,13 @@ sub match_token_at_36 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 36;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -3665,13 +3581,13 @@ sub match_token_at_36 {
 sub match_token_at_37 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 37;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Tags');
@@ -3679,13 +3595,13 @@ sub match_token_at_37 {
         $self->_build($context, $token);
         return 38;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 37;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -3707,7 +3623,7 @@ sub match_token_at_37 {
 sub match_token_at_38 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -3719,26 +3635,26 @@ sub match_token_at_38 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 38;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 40;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesTable');
         $self->_build($context, $token);
         return 41;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -3750,7 +3666,7 @@ sub match_token_at_38 {
         return 37;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -3764,7 +3680,7 @@ sub match_token_at_38 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -3778,7 +3694,7 @@ sub match_token_at_38 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -3788,7 +3704,7 @@ sub match_token_at_38 {
         $self->_build($context, $token);
         return 38;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -3800,7 +3716,7 @@ sub match_token_at_38 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -3813,7 +3729,7 @@ sub match_token_at_38 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'Description');
@@ -3836,7 +3752,7 @@ sub match_token_at_38 {
 sub match_token_at_39 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -3849,14 +3765,14 @@ sub match_token_at_39 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
         $self->_build($context, $token);
         return 40;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -3864,7 +3780,7 @@ sub match_token_at_39 {
         $self->_build($context, $token);
         return 41;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -3877,7 +3793,7 @@ sub match_token_at_39 {
         return 37;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -3892,7 +3808,7 @@ sub match_token_at_39 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -3907,7 +3823,7 @@ sub match_token_at_39 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -3918,7 +3834,7 @@ sub match_token_at_39 {
         $self->_build($context, $token);
         return 38;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -3931,7 +3847,7 @@ sub match_token_at_39 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Description');
@@ -3945,7 +3861,7 @@ sub match_token_at_39 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -3967,7 +3883,7 @@ sub match_token_at_39 {
 sub match_token_at_40 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -3979,20 +3895,20 @@ sub match_token_at_40 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 40;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_start_rule($context, 'ExamplesTable');
         $self->_build($context, $token);
         return 41;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -4004,7 +3920,7 @@ sub match_token_at_40 {
         return 37;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -4018,7 +3934,7 @@ sub match_token_at_40 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -4032,7 +3948,7 @@ sub match_token_at_40 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -4042,7 +3958,7 @@ sub match_token_at_40 {
         $self->_build($context, $token);
         return 38;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -4054,7 +3970,7 @@ sub match_token_at_40 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'Examples');
@@ -4067,7 +3983,7 @@ sub match_token_at_40 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -4089,7 +4005,7 @@ sub match_token_at_40 {
 sub match_token_at_41 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
@@ -4102,13 +4018,13 @@ sub match_token_at_41 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_TableRow($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TableRow($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 41;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -4121,7 +4037,7 @@ sub match_token_at_41 {
         return 37;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -4136,7 +4052,7 @@ sub match_token_at_41 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
@@ -4151,7 +4067,7 @@ sub match_token_at_41 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
@@ -4162,7 +4078,7 @@ sub match_token_at_41 {
         $self->_build($context, $token);
         return 38;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
@@ -4175,7 +4091,7 @@ sub match_token_at_41 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'ExamplesTable');
@@ -4189,13 +4105,13 @@ sub match_token_at_41 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 41;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -4217,13 +4133,13 @@ sub match_token_at_41 {
 sub match_token_at_43 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    ($ok, $err) = $context->token_matcher->match_DocStringSeparator($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 44;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -4245,7 +4161,7 @@ sub match_token_at_43 {
 sub match_token_at_44 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4257,7 +4173,7 @@ sub match_token_at_44 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4266,7 +4182,7 @@ sub match_token_at_44 {
         $self->_build($context, $token);
         return 35;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -4278,7 +4194,7 @@ sub match_token_at_44 {
         return 37;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -4292,7 +4208,7 @@ sub match_token_at_44 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4306,7 +4222,7 @@ sub match_token_at_44 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4316,7 +4232,7 @@ sub match_token_at_44 {
         $self->_build($context, $token);
         return 38;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4328,7 +4244,7 @@ sub match_token_at_44 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4341,13 +4257,13 @@ sub match_token_at_44 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 44;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -4369,13 +4285,13 @@ sub match_token_at_44 {
 sub match_token_at_45 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    ($ok, $err) = $context->token_matcher->match_DocStringSeparator($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 46;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -4397,7 +4313,7 @@ sub match_token_at_45 {
 sub match_token_at_46 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4408,7 +4324,7 @@ sub match_token_at_46 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4417,7 +4333,7 @@ sub match_token_at_46 {
         $self->_build($context, $token);
         return 29;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -4430,7 +4346,7 @@ sub match_token_at_46 {
         return 31;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4443,7 +4359,7 @@ sub match_token_at_46 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4454,7 +4370,7 @@ sub match_token_at_46 {
         $self->_build($context, $token);
         return 32;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4466,13 +4382,13 @@ sub match_token_at_46 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 46;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -4494,13 +4410,13 @@ sub match_token_at_46 {
 sub match_token_at_47 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    ($ok, $err) = $context->token_matcher->match_DocStringSeparator($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 48;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -4522,7 +4438,7 @@ sub match_token_at_47 {
 sub match_token_at_48 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4533,7 +4449,7 @@ sub match_token_at_48 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4542,7 +4458,7 @@ sub match_token_at_48 {
         $self->_build($context, $token);
         return 15;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_1($context, $token)) {
@@ -4554,7 +4470,7 @@ sub match_token_at_48 {
         return 17;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -4568,7 +4484,7 @@ sub match_token_at_48 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4581,7 +4497,7 @@ sub match_token_at_48 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ExamplesLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ExamplesLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4591,7 +4507,7 @@ sub match_token_at_48 {
         $self->_build($context, $token);
         return 18;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4603,7 +4519,7 @@ sub match_token_at_48 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4615,13 +4531,13 @@ sub match_token_at_48 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 48;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -4643,13 +4559,13 @@ sub match_token_at_48 {
 sub match_token_at_49 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_DocStringSeparator($context, $token);
+    ($ok, $err) = $context->token_matcher->match_DocStringSeparator($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 50;
     }
-    ($ok, $err) = $self->match_Other($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Other($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -4671,7 +4587,7 @@ sub match_token_at_49 {
 sub match_token_at_50 {
     my ( $self, $token, $context ) = @_;
     my ( $ok, $err );
-    ($ok, $err) = $self->match_EOF($context, $token);
+    ($ok, $err) = $context->token_matcher->match_EOF($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4681,7 +4597,7 @@ sub match_token_at_50 {
         $self->_build($context, $token);
         return 42;
     }
-    ($ok, $err) = $self->match_StepLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_StepLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4690,7 +4606,7 @@ sub match_token_at_50 {
         $self->_build($context, $token);
         return 9;
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         if ($self->lookahead_0($context, $token)) {
@@ -4703,7 +4619,7 @@ sub match_token_at_50 {
         return 11;
         }
     }
-    ($ok, $err) = $self->match_TagLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_TagLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4715,7 +4631,7 @@ sub match_token_at_50 {
         $self->_build($context, $token);
         return 22;
     }
-    ($ok, $err) = $self->match_ScenarioLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_ScenarioLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4726,7 +4642,7 @@ sub match_token_at_50 {
         $self->_build($context, $token);
         return 12;
     }
-    ($ok, $err) = $self->match_RuleLine($context, $token);
+    ($ok, $err) = $context->token_matcher->match_RuleLine($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_end_rule($context, 'DocString');
@@ -4737,13 +4653,13 @@ sub match_token_at_50 {
         $self->_build($context, $token);
         return 23;
     }
-    ($ok, $err) = $self->match_Comment($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Comment($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
         return 50;
     }
-    ($ok, $err) = $self->match_Empty($context, $token);
+    ($ok, $err) = $context->token_matcher->match_Empty($token);
     if ($ok) {
         $self->add_error( $context, $err ) if $err;
         $self->_build($context, $token);
@@ -4778,14 +4694,14 @@ sub lookahead_0 {
         push( @queue, $token );
 
 
-        ($match) = $self->match_ScenarioLine($context, $token);
+        ($match) = $context->token_matcher->match_ScenarioLine($token);
         last if $match;
 
-        ($ok) = $self->match_Empty($context, $token);
+        ($ok) = $context->token_matcher->match_Empty($token);
         next if $ok;
-        ($ok) = $self->match_Comment($context, $token);
+        ($ok) = $context->token_matcher->match_Comment($token);
         next if $ok;
-        ($ok) = $self->match_TagLine($context, $token);
+        ($ok) = $context->token_matcher->match_TagLine($token);
         next if $ok;
         last;
     }
@@ -4809,14 +4725,14 @@ sub lookahead_1 {
         push( @queue, $token );
 
 
-        ($match) = $self->match_ExamplesLine($context, $token);
+        ($match) = $context->token_matcher->match_ExamplesLine($token);
         last if $match;
 
-        ($ok) = $self->match_Empty($context, $token);
+        ($ok) = $context->token_matcher->match_Empty($token);
         next if $ok;
-        ($ok) = $self->match_Comment($context, $token);
+        ($ok) = $context->token_matcher->match_Comment($token);
         next if $ok;
-        ($ok) = $self->match_TagLine($context, $token);
+        ($ok) = $context->token_matcher->match_TagLine($token);
         next if $ok;
         last;
     }

--- a/perl/lib/Gherkin/ParserBase.pm
+++ b/perl/lib/Gherkin/ParserBase.pm
@@ -64,18 +64,4 @@ sub _build {
     }
 }
 
-sub handle_external_error {
-    my ( $self, $context, $action ) = @_;
-    return $action->() if $self->stop_at_first_error;
-
-    my $result = eval { $action->() };
-    return $result unless $@;
-
-    # Non-structured exceptions
-    die $@ unless ref $@;
-
-    $self->add_error( $context, $@ );
-    return 0; # failed
-}
-
 1;

--- a/perl/lib/Gherkin/ParserContext.pm
+++ b/perl/lib/Gherkin/ParserContext.pm
@@ -19,7 +19,7 @@ sub add_tokens { my $self = shift; push( @{ $self->token_queue }, @_ ); }
 sub errors     { my $self = shift; return @{ $self->_errors } }
 sub add_errors {
     my $self = shift;
-    $self->_errors( [ uniq( @{ $self->_errors }, @_ ) ] );
+    push @{ $self->{'_errors'} }, @_;
 }
 
 sub read_token {

--- a/perl/lib/Gherkin/TokenMatcher.pm
+++ b/perl/lib/Gherkin/TokenMatcher.pm
@@ -96,7 +96,7 @@ sub match_ExamplesLine {
 
 sub match_Language {
     my ( $self, $token ) = @_;
-    if ( $token->line->get_line_text =~ $LANGUAGE_RE ) {
+    if ( $token->line and $token->line->get_line_text =~ $LANGUAGE_RE ) {
         my $dialect_name = $1;
         $self->_set_token_matched( $token,
                                    Language => { text => $dialect_name } );
@@ -110,7 +110,7 @@ sub match_Language {
 
 sub match_TagLine {
     my ( $self, $token ) = @_;
-    return unless $token->line->startswith('@');
+    return unless $token->line and $token->line->startswith('@');
 
     my ($tags, $err) = $token->line->tags;
     $self->_set_token_matched( $token,
@@ -120,6 +120,7 @@ sub match_TagLine {
 
 sub _match_title_line {
     my ( $self, $token, $token_type, $keywords ) = @_;
+    return unless $token->line;
 
     for my $keyword (@$keywords) {
         if ( $token->line->startswith_title_keyword($keyword) ) {
@@ -171,14 +172,14 @@ sub match_EOF {
 
 sub match_Empty {
     my ( $self, $token ) = @_;
-    return unless $token->line->is_empty;
+    return unless $token->line and $token->line->is_empty;
     $self->_set_token_matched( $token, Empty => { indent => 0 } );
     return 1;
 }
 
 sub match_Comment {
     my ( $self, $token ) = @_;
-    return unless $token->line->startswith('#');
+    return unless $token->line and $token->line->startswith('#');
 
     my $comment_text = $token->line->line_text;
     $comment_text =~ s/\r\n$//;    # Why?
@@ -190,6 +191,7 @@ sub match_Comment {
 
 sub match_Other {
     my ( $self, $token ) = @_;
+    return unless $token->line;
 
     # take the entire line, except removing DocString indents
     my $text = $token->line->get_line_text( $self->_indent_to_remove );

--- a/perl/lib/Gherkin/TokenMatcher.pm
+++ b/perl/lib/Gherkin/TokenMatcher.pm
@@ -79,7 +79,7 @@ sub match_ScenarioLine {
         ScenarioLine => $self->dialect->Scenario )
         or $self->_match_title_line(
             $token,
-            ScenarioLine => $self->dialect->ScenarioOutline );;
+            ScenarioLine => $self->dialect->ScenarioOutline );
 }
 
 sub match_BackgroundLine {
@@ -99,9 +99,10 @@ sub match_Language {
     if ( $token->line->get_line_text =~ $LANGUAGE_RE ) {
         my $dialect_name = $1;
         $self->_set_token_matched( $token,
-            Language => { text => $dialect_name } );
-        $self->change_dialect( $dialect_name, $token->location );
-        return 1;
+                                   Language => { text => $dialect_name } );
+        local $@;
+        eval { $self->change_dialect( $dialect_name, $token->location ) };
+        return (1, $@);
     } else {
         return;
     }
@@ -110,9 +111,11 @@ sub match_Language {
 sub match_TagLine {
     my ( $self, $token ) = @_;
     return unless $token->line->startswith('@');
+
+    my ($tags, $err) = $token->line->tags;
     $self->_set_token_matched( $token,
-        TagLine => { items => $token->line->tags } );
-    return 1;
+                               TagLine => { items => $tags } );
+    return (1, $err);
 }
 
 sub _match_title_line {


### PR DESCRIPTION
### 🤔 What's changed?

The Perl token matcher gained the ability to accept a token and at the same time indicate a token parser error. Before - due to the use of exceptions to indicate parser errors - it would only be possible to achieve one *or* the other.

### ⚡️ What's your motivation? 

By making this change, the Perl implementation is able to report the parsing error exactly once, instead of - as it does now - requiring to de-duplicate errors which might be reported multiple times (this can happen due to the fact that the lookahead function of the parser triggers a parser error.

### 🏷️ What kind of change is this?

:bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

Since the error of the duplicates has already been fixed (the fast way), PR is more of a maintenance type of PR.

### ♻️ Anything particular you want feedback on?

During the weekly meeting, we assessed that exceptions are not the way to return data from a function.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I *haven't* changed the behaviour of the code
- [x] My change *doesn't* require a change to the documentation.
- [x] Users should *not have to* know about my change (as it's fully internal behaviour to the parser
