### PR TITLE
Added .net 8 to test platforms

### DIFF
--- a/.github/workflows/release-nuget.yaml
+++ b/.github/workflows/release-nuget.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - uses: cucumber/action-publish-nuget@v1.0.0
         with:
           nuget-api-key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -19,15 +19,14 @@ on:
 jobs:
   test-dotnet:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: | 
+          dotnet-version: |
             6.0.x
             7.0.x
-
+            8.0.x
       - run: dotnet test
         working-directory: dotnet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ## [Unreleased]
 ### Changed
+- [.NET] Bump sdk to .net 8. Added .net 8 to test platforms.
 - [Go] Upgraded messages to v22
 - [Go] Improve performance - don't compile regex on matcher create
 - [Perl] Fix release packaging

--- a/dotnet/Gherkin.Specs/Gherkin.Specs.csproj
+++ b/dotnet/Gherkin.Specs/Gherkin.Specs.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <StartupObject>Gherkin.Specs.CLI.Program</StartupObject>
   </PropertyGroup>
@@ -21,7 +21,4 @@
     <ProjectReference Include="..\Gherkin\Gherkin.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
### 🤔 What's changed?

- .NET sdk was updated to version 8
- Added .NET 8 to test platforms (new test platforms: .net 6, .net 7, .net 8)
- Use c# lang version 12

### ⚡️ What's your motivation? 

.NET 8 soon will be released. This is LTS version and will be good to add it to testing platforms

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
- [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
 - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
