### PR TITLE
i18n: Add 'ed' to Italian

### DIFF
--- a/c/src/dialect.c
+++ b/c/src/dialect.c
@@ -1880,8 +1880,8 @@ static const Dialect is_dialect = {
         &is_then_keywords,
         &is_when_keywords };
 
-static const wchar_t* const it_and_KEYWORDS[] = { L"* ", L"E " };
-static const Keywords it_and_keywords = { 2, it_and_KEYWORDS };
+static const wchar_t* const it_and_KEYWORDS[] = { L"* ", L"E ", L"Ed " };
+static const Keywords it_and_keywords = { 3, it_and_KEYWORDS };
 
 static const wchar_t* const it_background_KEYWORDS[] = { L"Contesto" };
 static const Keywords it_background_keywords = { 1, it_background_KEYWORDS };

--- a/dart/assets/gherkin-languages.json
+++ b/dart/assets/gherkin-languages.json
@@ -1886,7 +1886,8 @@
   "it": {
     "and": [
       "* ",
-      "E "
+      "E ",
+      "Ed "
     ],
     "background": [
       "Contesto"

--- a/dotnet/Gherkin/gherkin-languages.json
+++ b/dotnet/Gherkin/gherkin-languages.json
@@ -1886,7 +1886,8 @@
   "it": {
     "and": [
       "* ",
-      "E "
+      "E ",
+      "Ed "
     ],
     "background": [
       "Contesto"

--- a/elixir/priv/gherkin_languages.json
+++ b/elixir/priv/gherkin_languages.json
@@ -1886,7 +1886,8 @@
   "it": {
     "and": [
       "* ",
-      "E "
+      "E ",
+      "Ed "
     ],
     "background": [
       "Contesto"

--- a/gherkin-languages.json
+++ b/gherkin-languages.json
@@ -1886,7 +1886,8 @@
   "it": {
     "and": [
       "* ",
-      "E "
+      "E ",
+      "Ed "
     ],
     "background": [
       "Contesto"

--- a/go/dialects_builtin.go
+++ b/go/dialects_builtin.go
@@ -2659,6 +2659,7 @@ var builtinDialects = gherkinDialectMap{
 			and: {
 				"* ",
 				"E ",
+				"Ed ",
 			},
 			but: {
 				"* ",
@@ -2679,6 +2680,8 @@ var builtinDialects = gherkinDialectMap{
 			"Allora ": messages.StepKeywordType_OUTCOME,
 
 			"E ": messages.StepKeywordType_CONJUNCTION,
+
+			"Ed ": messages.StepKeywordType_CONJUNCTION,
 
 			"Ma ": messages.StepKeywordType_CONJUNCTION,
 

--- a/javascript/src/gherkin-languages.json
+++ b/javascript/src/gherkin-languages.json
@@ -1886,7 +1886,8 @@
   "it": {
     "and": [
       "* ",
-      "E "
+      "E ",
+      "Ed "
     ],
     "background": [
       "Contesto"

--- a/php/resources/gherkin-languages.json
+++ b/php/resources/gherkin-languages.json
@@ -1886,7 +1886,8 @@
   "it": {
     "and": [
       "* ",
-      "E "
+      "E ",
+      "Ed "
     ],
     "background": [
       "Contesto"

--- a/python/gherkin/gherkin-languages.json
+++ b/python/gherkin/gherkin-languages.json
@@ -1886,7 +1886,8 @@
   "it": {
     "and": [
       "* ",
-      "E "
+      "E ",
+      "Ed "
     ],
     "background": [
       "Contesto"

--- a/ruby/lib/gherkin/gherkin-languages.json
+++ b/ruby/lib/gherkin/gherkin-languages.json
@@ -1886,7 +1886,8 @@
   "it": {
     "and": [
       "* ",
-      "E "
+      "E ",
+      "Ed "
     ],
     "background": [
       "Contesto"


### PR DESCRIPTION
Added a translation of "and" in Italian: "ed".

"Ed" is used when the following word starts with a vowel, to separate the vowel sounds.

Example:
``` gherkin
Dato che ho una pizza
Quando qualcuna mette ananas sulla mia pizza
Ed adoro le mie papille gustative 
Allora non mangio la mia pizza
```