### PR TITLE
Skip tests for implementations without change

### DIFF
--- a/.github/workflows/test-c.yml
+++ b/.github/workflows/test-c.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - main
       - renovate/**
+    paths:
+      - c/**
+      - testdata/**
   pull_request:
     branches:
       - main
+    paths:
+      - c/**
+      - testdata/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-dart.yml
+++ b/.github/workflows/test-dart.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - main
       - renovate/**
+    paths:
+      - dart/**
+      - testdata/**
   pull_request:
     branches:
       - main
+    paths:
+      - c/**
+      - testdata/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - main
       - renovate/**
+    paths:
+      - dotnet/**
+      - testdata/**
   pull_request:
     branches:
       - main
+    paths:
+      - c/**
+      - testdata/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - main
       - renovate/**
+    paths:
+      - go/**
+      - testdata/**
   pull_request:
     branches:
       - main
+    paths:
+      - c/**
+      - testdata/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - main
       - renovate/**
+    paths:
+      - java/**
+      - testdata/**
   pull_request:
     branches:
       - main
+    paths:
+      - c/**
+      - testdata/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - main
       - renovate/**
+    paths:
+      - javascript/**
+      - testdata/**
   pull_request:
     branches:
       - main
+    paths:
+      - c/**
+      - testdata/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-perl.yml
+++ b/.github/workflows/test-perl.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - main
       - renovate/**
+    paths:
+      - perl/**
+      - testdata/**
   pull_request:
     branches:
       - main
+    paths:
+      - c/**
+      - testdata/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - main
       - renovate/**
+    paths:
+      - php/**
+      - testdata/**
   pull_request:
     branches:
       - main
+    paths:
+      - c/**
+      - testdata/**
   workflow_call:
 
 permissions:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -8,9 +8,15 @@ on:
     branches:
       - main
       - renovate/**
+    paths:
+      - php/**
+      - testdata/**
   pull_request:
     branches:
       - main
+    paths:
+      - c/**
+      - testdata/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - main
       - renovate/**
+    paths:
+      - ruby/**
+      - testdata/**
   pull_request:
     branches:
       - main
+    paths:
+      - c/**
+      - testdata/**
   workflow_call:
 
 jobs:


### PR DESCRIPTION
### 🤔 What's changed?

Currently, we run ~50 for each commit. This takes up quite a lot of CI resources, resulting in long wait times. Typically, (especially with Renovate) only a single language changes.
