### PR TITLE
Check PHP has populated $argv

### DIFF
--- a/php/bin/gherkin
+++ b/php/bin/gherkin
@@ -7,11 +7,14 @@ use Cucumber\Gherkin\GherkinParser;
 use Cucumber\Messages\Source;
 use Cucumber\Messages\Streams\NdJson\NdJsonStreamWriter;
 
+assert(is_array($argv), "Script must be run from the command line");
+
 $options = ['predictable-ids', 'no-source', 'no-ast', 'no-pickles'];
 
 $selectedOptions = getopt('', $options, $restIndex);
 
 $paths = array_slice($argv, $restIndex);
+
 // lazily-read list of Sources
 $sources = (
     /** @param list<string> $paths */

--- a/php/bin/gherkin-generate-tokens
+++ b/php/bin/gherkin-generate-tokens
@@ -9,6 +9,8 @@ namespace Cucumber\Gherkin;
 
 require __DIR__ . '/../vendor/autoload.php';
 
+assert(is_array($argv), "Script must be run from the command line");
+
 $parser = new Parser(new TokenFormatterBuilder());
 
 // first element is the script name

--- a/php/composer.json
+++ b/php/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",
-        "vimeo/psalm": "5.5.0",
+        "vimeo/psalm": "5.15.0",
         "friendsofphp/php-cs-fixer": "^3.5",
         "psalm/plugin-phpunit": "^0.18.0",
         "nikic/php-parser": "^4.14"


### PR DESCRIPTION
This will always be a `non-empty-list<string>` in a CLI script but because it might be `null` in other contexts Psalm is strict about checking for it here
