### PR TITLE
i18n: Add 'regel' for 'rule' in Dutch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 - (i18n) Added Malayalam localization
 - (i18n) Added 'ed' to Italian ([#31](https://github.com/cucumber/gherkin/issues/160))
 - (i18n) Added Danish translation of "Rule"
+- (i18n) Added Dutch translation of "Rule"
 
 ## [26.2.0] - 2023-04-07
 ### Changed

--- a/c/src/dialect.c
+++ b/c/src/dialect.c
@@ -2509,7 +2509,7 @@ static const Keywords nl_feature_keywords = { 1, nl_feature_KEYWORDS };
 static const wchar_t* const nl_given_KEYWORDS[] = { L"* ", L"Gegeven ", L"Stel " };
 static const Keywords nl_given_keywords = { 3, nl_given_KEYWORDS };
 
-static const wchar_t* const nl_rule_KEYWORDS[] = { L"Rule" };
+static const wchar_t* const nl_rule_KEYWORDS[] = { L"Regel" };
 static const Keywords nl_rule_keywords = { 1, nl_rule_KEYWORDS };
 
 static const wchar_t* const nl_scenario_KEYWORDS[] = { L"Voorbeeld", L"Scenario" };

--- a/dart/assets/gherkin-languages.json
+++ b/dart/assets/gherkin-languages.json
@@ -2533,7 +2533,7 @@
     "name": "Dutch",
     "native": "Nederlands",
     "rule": [
-      "Rule"
+      "Regel"
     ],
     "scenario": [
       "Voorbeeld",

--- a/dotnet/Gherkin/gherkin-languages.json
+++ b/dotnet/Gherkin/gherkin-languages.json
@@ -2533,7 +2533,7 @@
     "name": "Dutch",
     "native": "Nederlands",
     "rule": [
-      "Rule"
+      "Regel"
     ],
     "scenario": [
       "Voorbeeld",

--- a/elixir/priv/gherkin_languages.json
+++ b/elixir/priv/gherkin_languages.json
@@ -2533,7 +2533,7 @@
     "name": "Dutch",
     "native": "Nederlands",
     "rule": [
-      "Rule"
+      "Regel"
     ],
     "scenario": [
       "Voorbeeld",

--- a/gherkin-languages.json
+++ b/gherkin-languages.json
@@ -2533,7 +2533,7 @@
     "name": "Dutch",
     "native": "Nederlands",
     "rule": [
-      "Rule"
+      "Regel"
     ],
     "scenario": [
       "Voorbeeld",

--- a/go/dialects_builtin.go
+++ b/go/dialects_builtin.go
@@ -3474,7 +3474,7 @@ var builtinDialects = gherkinDialectMap{
 				"Functionaliteit",
 			},
 			rule: {
-				"Rule",
+				"Regel",
 			},
 			background: {
 				"Achtergrond",

--- a/javascript/src/gherkin-languages.json
+++ b/javascript/src/gherkin-languages.json
@@ -2533,7 +2533,7 @@
     "name": "Dutch",
     "native": "Nederlands",
     "rule": [
-      "Rule"
+      "Regel"
     ],
     "scenario": [
       "Voorbeeld",

--- a/php/resources/gherkin-languages.json
+++ b/php/resources/gherkin-languages.json
@@ -2533,7 +2533,7 @@
     "name": "Dutch",
     "native": "Nederlands",
     "rule": [
-      "Rule"
+      "Regel"
     ],
     "scenario": [
       "Voorbeeld",

--- a/python/gherkin/gherkin-languages.json
+++ b/python/gherkin/gherkin-languages.json
@@ -2533,7 +2533,7 @@
     "name": "Dutch",
     "native": "Nederlands",
     "rule": [
-      "Rule"
+      "Regel"
     ],
     "scenario": [
       "Voorbeeld",

--- a/ruby/lib/gherkin/gherkin-languages.json
+++ b/ruby/lib/gherkin/gherkin-languages.json
@@ -2533,7 +2533,7 @@
     "name": "Dutch",
     "native": "Nederlands",
     "rule": [
-      "Rule"
+      "Regel"
     ],
     "scenario": [
       "Voorbeeld",


### PR DESCRIPTION
Added a translation of "rule" in Dutch: "regel"

Resolves: https://github.com/cucumber/gherkin/issues/105