### PR TITLE
Fix for get_comments prototype deprecation

### DIFF
--- a/c/src/ast_builder.c
+++ b/c/src/ast_builder.c
@@ -64,7 +64,7 @@ static wchar_t* create_multi_line_text_from_tokens(int text_length, int line_cou
 
 static const wchar_t* get_description(AstNode* ast_node);
 
-static const Comments* get_comments();
+static const Comments* get_comments(AstBuilder* ast_builder);
 
 static void ensure_cell_count(ErrorList* errors, const TableRows* rows, const TableRow* header, AstNode* ast_node);
 


### PR DESCRIPTION
### 🤔 What's changed?

Passing arguments to 'get_comments' without a prototype is deprecated in all versions of C and is not supported in C2x. Most of the other functions here have correct arguments passed to them except `get_comments`.

### ⚡️ What's your motivation? 
Fixing a bug in Cucumber.ml that depends on gherkin-c/libgherkin.so. I get this warning on macOS Sonoma.
```
cc -c -Wall -Werror -g -fPIC  -MMD -MP -MF ../objs/ast_builder.d -I ../include -I . ast_builder.c -o ../objs/ast_builder.o
ast_builder.c:250:92: error: passing arguments to 'get_comments' without a prototype is deprecated in all versions of C and is not supported in C2x [-Werror,-Wdeprecated-non-prototype]
        const GherkinDocument* gherkin_document = GherkinDocument_new(feature, get_comments(ast_builder));
                                                                                           ^
ast_builder.c:67:24: error: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a subsequent definition [-Werror,-Wdeprecated-non-prototype]
static const Comments* get_comments();
                       ^
ast_builder.c:489:24: note: conflicting prototype is here
static const Comments* get_comments(AstBuilder* ast_builder) {
                       ^
2 errors generated.
make[1]: *** [../objs/ast_builder.o] Error 1
make: *** [libs] Error 2
```
Environment:
```
$ cc --version
Apple clang version 15.0.0 (clang-1500.0.40.1)
Target: x86_64-apple-darwin22.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
$ sw_vers
ProductName:		macOS
ProductVersion:		13.6
BuildVersion:		22G120

```
### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

I have only tested on macOS Sonoma. Testing on other platforms would be useful.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
