### PR TITLE
Remove duplicate token matcher Python code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org).
 This document is formatted according to the principles of [Keep A CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- [Python] Removed duplicate code in markdown token matcher ([#205](https://github.com/cucumber/gherkin/pull/205))
 
 ## [27.0.0] - 2023-09-15
 ### Added

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -5,6 +5,7 @@ acceptance/
 *.pyc
 dist/
 build/
+venv/
 .tox/
 .coverage
 .coverage.*

--- a/python/MANIFEST
+++ b/python/MANIFEST
@@ -18,6 +18,7 @@ gherkin/parser.py
 gherkin/token.py
 gherkin/token_formatter_builder.py
 gherkin/token_matcher.py
+gherkin/token_matcher_markdown.py
 gherkin/token_scanner.py
 gherkin/pickles/__init__.py
 gherkin/pickles/compiler.py

--- a/python/gherkin/token_matcher.py
+++ b/python/gherkin/token_matcher.py
@@ -112,11 +112,15 @@ class TokenMatcher(object):
             # close
             return self._match_DocStringSeparator(token, self._active_doc_string_separator, False)
 
+    @staticmethod
+    def _default_docstring_content_type():
+        return None
+
     def _match_DocStringSeparator(self, token, separator, is_open):
         if not token.line.startswith(separator):
             return False
 
-        content_type = None
+        content_type = self._default_docstring_content_type()
         if is_open:
             content_type = token.line.get_rest_trimmed(len(separator))
             self._active_doc_string_separator = separator


### PR DESCRIPTION
### 🤔 What's changed?

Change Python implementation of markdown token matcher to inherit from feature file token matcher.

### ⚡️ What's your motivation? 

- Remove duplicated code - ensuring a source of truth and improved maintainability.
- Add missing entry in manifest for markdown token matcher - added automatically as part of build process when running test suite through `tox`

Existing test suite remained compatible for the feature file and markdown matchers after the change - including with Python 2.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

NA.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.