### PR TITLE
CI: Update latest PHP version to last non-EOL version

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.1']
+        php: ['8.2']
         composer-mode: ['low-deps', 'high-deps']
 
     steps:


### PR DESCRIPTION


### 🤔 What's changed?

Went from 8.1 to 8.2.

### ⚡️ What's your motivation? 

8.1 is EOL.
8.2 is still supported.

When reading https://phpunit.de/announcements/phpunit-11.html I saw that since Feb 2 2024, 8.2 is the oldest still-supported PHP version.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

-

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

