### PR TITLE
[php] Bump required version of the php-cs-fixer

### DIFF
--- a/php/composer.json
+++ b/php/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "phpunit/phpunit": "^10.0",
         "vimeo/psalm": "5.19.1",
-        "friendsofphp/php-cs-fixer": "^3.5",
+        "friendsofphp/php-cs-fixer": "^3.51",
         "psalm/plugin-phpunit": "^0.18.0",
         "nikic/php-parser": "^4.14"
     },


### PR DESCRIPTION
### 🤔 What's changed?

This version of the php-cs-fixer supports versions of PHP in our matrix.

https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.51.0

That project's  README states that it supports very new versions.


Our CI error message output was:


```
Run vendor/bin/php-cs-fixer --dry-run --diff fix
  vendor/bin/php-cs-fixer --dry-run --diff fix
  vendor/bin/psalm --no-cache
  vendor/bin/phpunit
  shell: /usr/bin/bash -e {0}
  env:
    COMPOSER_PROCESS_TIMEOUT: 0
    COMPOSER_NO_INTERACTION: 1
    COMPOSER_NO_AUDIT: 1
    COMPOSER_AUTH: {"github-oauth": {"github.com": "***"}}
PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.1.*.
Current PHP version: 8.2.15.
To ignore this requirement please set `PHP_CS_FIXER_IGNORE_ENV`.
If you use PHP version higher than supported, you may experience code modified in a wrong way.
Please report such cases at https://github.com/FriendsOfPHP/PHP-CS-Fixer .
```




Result after the change

<img width="855" alt="image" src="https://github.com/cucumber/gherkin/assets/211/5050cd42-7e00-453d-981c-b58fefff7c20">

### ⚡️ What's your motivation? 

Saw version warning failures in the CI output for unrelated package updates, when we got to the "fix code style" step.


### 🏷️ What kind of change is this?


- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)



- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

