### PR TITLE
[php] Configure Psalm 6 default settings findUnusedBaselineEntry, findUnusedCode

### DIFF
--- a/php/composer.json
+++ b/php/composer.json
@@ -18,7 +18,7 @@
         "cucumber/messages": ">=19.1.4 <=24"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^10.5",
         "vimeo/psalm": "5.19.1",
         "friendsofphp/php-cs-fixer": "^3.51",
         "psalm/plugin-phpunit": "^0.18.0",

--- a/php/phpunit.xml
+++ b/php/phpunit.xml
@@ -1,21 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         cacheDirectory=".phpunit.cache"
-         executionOrder="depends,defects"
-         beStrictAboutOutputDuringTests="true"
-         failOnRisky="true"
-         failOnWarning="true"
-         beStrictAboutCoverageMetadata="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" cacheDirectory=".phpunit.cache" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" failOnRisky="true" failOnWarning="true" beStrictAboutCoverageMetadata="true">
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/php/psalm.xml
+++ b/php/psalm.xml
@@ -2,6 +2,8 @@
 <psalm
     errorLevel="1"
     resolveFromConfigFile="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/php/psalm.xml
+++ b/php/psalm.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="1"
-    resolveFromConfigFile="false"
-    findUnusedBaselineEntry="false"
+    resolveFromConfigFile="true"
+    findUnusedBaselineEntry="true"
     findUnusedCode="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/php/psalm.xml
+++ b/php/psalm.xml
@@ -2,8 +2,8 @@
 <psalm
     errorLevel="1"
     resolveFromConfigFile="true"
-    findUnusedBaselineEntry="true"
-    findUnusedCode="true"
+    findUnusedBaselineEntry="false"
+    findUnusedCode="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/php/psalm.xml
+++ b/php/psalm.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="1"
-    resolveFromConfigFile="true"
-    findUnusedBaselineEntry="true"
+    resolveFromConfigFile="false"
+    findUnusedBaselineEntry="false"
     findUnusedCode="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/php/src/AstNode.php
+++ b/php/src/AstNode.php
@@ -62,8 +62,14 @@ final class AstNode
         return $items[0] ?? $defaultValue;
     }
 
-    /** needed for non-object return */
-    public function getSingleUntyped(RuleType $ruleType, mixed $defaultValue = null): mixed
+    /**
+     * needed for non-object return
+     *
+     * @param null|string $defaultValue
+     *
+     * @psalm-param ''|null $defaultValue
+     */
+    public function getSingleUntyped(RuleType $ruleType, string|null $defaultValue = null): mixed
     {
         $items = $this->subItems[$ruleType->name] ?? [];
 

--- a/php/src/ParserException/UnexpectedEofException.php
+++ b/php/src/ParserException/UnexpectedEofException.php
@@ -7,6 +7,9 @@ namespace Cucumber\Gherkin\ParserException;
 use Cucumber\Gherkin\ParserException;
 use Cucumber\Gherkin\Token;
 
+/**
+ * @psalm-api
+ */
 final class UnexpectedEofException extends ParserException
 {
     /**

--- a/php/src/ParserException/UnexpectedTokenException.php
+++ b/php/src/ParserException/UnexpectedTokenException.php
@@ -8,6 +8,9 @@ use Cucumber\Gherkin\Location;
 use Cucumber\Gherkin\ParserException;
 use Cucumber\Gherkin\Token;
 
+/**
+ * @psalm-api
+ */
 final class UnexpectedTokenException extends ParserException
 {
     /**


### PR DESCRIPTION
### 🤔 What's changed?

Psalm's offering news, and our CI had not configured those settings.

This PR fixes a warning that outputs that we should be explicit about this setting.

First, I picked enabling it as the solution. (And, then I continued on that path.)

<details>

<summary>Psalm in CI: found some issues: 9 errors found</summary>

```

░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
Error: src/AstNode.php:38:37: UnusedParam: Param #1 is never referenced in this method (see https://psalm.dev/135)
Error: src/GherkinParser.php:31:31: UnusedProperty: Cannot find any references to private property Cucumber\Gherkin\GherkinParser::$predictableIds (see https://psalm.dev/150)
Error: src/GherkinParser.php:46:21: PossiblyUnusedMethod: Cannot find any calls to method Cucumber\Gherkin\GherkinParser::parseString (see https://psalm.dev/087)
Error: src/Location.php:15:21: PossiblyUnusedMethod: Cannot find any calls to method Cucumber\Gherkin\Location::getColumn (see https://psalm.dev/087)
Error: src/Parser/ParserTrait.php:76:16: UnusedReturnValue: The return value for this private method is never used (see https://psalm.dev/272)
Error: src/ParserException/UnexpectedEofException.php:16:31: PossiblyUnusedProperty: Cannot find any references to property Cucumber\Gherkin\ParserException\UnexpectedEofException::$receivedToken (see https://psalm.dev/149)
Error: src/ParserException/UnexpectedEofException.php:17:31: PossiblyUnusedProperty: Cannot find any references to property Cucumber\Gherkin\ParserException\UnexpectedEofException::$expectedTokenTypes (see https://psalm.dev/149)
Error: src/ParserException/UnexpectedEofException.php:18:32: PossiblyUnusedProperty: Cannot find any references to property Cucumber\Gherkin\ParserException\UnexpectedEofException::$stateComment (see https://psalm.dev/149)
Error: src/ParserException/UnexpectedTokenException.php:19:32: PossiblyUnusedProperty: Cannot find any references to property Cucumber\Gherkin\ParserException\UnexpectedTokenException::$stateComment (see https://psalm.dev/149)
------------------------------
9 errors found
------------------------------
Psalm can automatically fix 3 of these issues.
Run Psalm again with 
--alter --issues=PossiblyUnusedMethod,MissingParamType --dry-run
to see what it can fix.
------------------------------

Checks took 3.46 seconds and used 110.339MB of memory
Psalm was able to infer types for 100% of the codebase
Error: Process completed with exit code 2.
```

</details>

OK, so perhaps "enable" wasn't the right way, let's see if disabling will lead to nicer output? I learned a little, and placed some Psalm annotations in the code, in order to tell Psalm "these properties on the exceptions, they're expected, across all our implementations".

That got us a shorter list of Psalm offenses.

<details>


<summary>Psalm in CI: 5 errors found</summary>

```

░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
Error: src/AstNode.php:38:37: UnusedParam: Param #1 is never referenced in this method (see https://psalm.dev/135)
Error: src/GherkinParser.php:31:31: UnusedProperty: Cannot find any references to private property Cucumber\Gherkin\GherkinParser::$predictableIds (see https://psalm.dev/150)
Error: src/GherkinParser.php:46:21: PossiblyUnusedMethod: Cannot find any calls to method Cucumber\Gherkin\GherkinParser::parseString (see https://psalm.dev/087)
Error: src/Location.php:15:21: PossiblyUnusedMethod: Cannot find any calls to method Cucumber\Gherkin\Location::getColumn (see https://psalm.dev/087)
Error: src/Parser/ParserTrait.php:76:16: UnusedReturnValue: The return value for this private method is never used (see https://psalm.dev/272)
------------------------------
5 errors found
------------------------------

```

</details>

Upon thinking about those issues reported, I sort of think that it can absolutely be that it's part of the API to have some unused parameters (in code like AST handling callbacks). So, perhaps they're _all_ `@psalm-api`.

### ⚡️ What's your motivation? 

CI output should be terse, clear and focused. This change hopes to make it less noisy.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
