### PR TITLE
Build every language on changes to the GitHub workflows

### DIFF
--- a/.github/workflows/test-c.yml
+++ b/.github/workflows/test-c.yml
@@ -8,12 +8,14 @@ on:
     paths:
       - c/**
       - testdata/**
+      - .github/**
   pull_request:
     branches:
       - main
     paths:
       - c/**
       - testdata/**
+      - .github/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-cpp.yml
+++ b/.github/workflows/test-cpp.yml
@@ -9,12 +9,14 @@ on:
     paths:
       - cpp/**
       - testdata/**
+      - .github/**
   pull_request:
     branches:
       - main
     paths:
       - cpp/**
       - testdata/**
+      - .github/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-dart.yml
+++ b/.github/workflows/test-dart.yml
@@ -8,12 +8,14 @@ on:
     paths:
       - dart/**
       - testdata/**
+      - .github/**
   pull_request:
     branches:
       - main
     paths:
       - dart/**
       - testdata/**
+      - .github/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -8,12 +8,14 @@ on:
     paths:
       - dotnet/**
       - testdata/**
+      - .github/**
   pull_request:
     branches:
       - main
     paths:
       - dotnet/**
       - testdata/**
+      - .github/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -8,12 +8,14 @@ on:
     paths:
       - go/**
       - testdata/**
+      - .github/**
   pull_request:
     branches:
       - main
     paths:
       - go/**
       - testdata/**
+      - .github/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -9,6 +9,7 @@ on:
       - java/**
       - testdata/**
       - gherkin-languages.json
+      - .github/**
   pull_request:
     branches:
       - main
@@ -16,6 +17,7 @@ on:
       - java/**
       - testdata/**
       - gherkin-languages.json
+      - .github/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -8,12 +8,14 @@ on:
     paths:
       - javascript/**
       - testdata/**
+      - .github/**
   pull_request:
     branches:
       - main
     paths:
       - javascript/**
       - testdata/**
+      - .github/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-perl.yml
+++ b/.github/workflows/test-perl.yml
@@ -8,12 +8,14 @@ on:
     paths:
       - perl/**
       - testdata/**
+      - .github/**
   pull_request:
     branches:
       - main
     paths:
       - perl/**
       - testdata/**
+      - .github/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -8,12 +8,14 @@ on:
     paths:
       - php/**
       - testdata/**
+      - .github/**
   pull_request:
     branches:
       - main
     paths:
       - php/**
       - testdata/**
+      - .github/**
   workflow_call:
 
 permissions:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -11,12 +11,14 @@ on:
     paths:
       - python/**
       - testdata/**
+      - .github/**
   pull_request:
     branches:
       - main
     paths:
       - python/**
       - testdata/**
+      - .github/**
   workflow_call:
 
 jobs:

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -8,12 +8,14 @@ on:
     paths:
       - ruby/**
       - testdata/**
+      - .github/**
   pull_request:
     branches:
       - main
     paths:
       - ruby/**
       - testdata/**
+      - .github/**
   workflow_call:
 
 jobs:


### PR DESCRIPTION
### 🤔 What's changed?

Build every language on changes to the GitHub workflows. 

### ⚡️ What's your motivation? 

We usually only run CI for the languages that changed because it is quite slow. But @olleolleolle was quite confused when CI didn't run for his changes (https://github.com/cucumber/gherkin/pull/233#issuecomment-1991341348). This should prevent that from happening.

### 🏷️ What kind of change is this?
- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

