### PR TITLE
[php] Try to follow Psalm tips

### DIFF
--- a/php/psalm.xml
+++ b/php/psalm.xml
@@ -2,8 +2,8 @@
 <psalm
     errorLevel="1"
     resolveFromConfigFile="true"
-    findUnusedBaselineEntry="false"
-    findUnusedCode="false"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/php/src/AstNode.php
+++ b/php/src/AstNode.php
@@ -31,11 +31,11 @@ final class AstNode
     /**
      * @template T of object
      *
-     * @param class-string<T> $expectedType
+     * @param class-string<T> $_expectedType
      *
      * @psalm-return list<T>
      */
-    public function getItems(string $expectedType, RuleType $ruleType): array
+    public function getItems(string $_expectedType, RuleType $ruleType): array
     {
         $items = $this->subItems[$ruleType->name] ?? [];
 

--- a/php/src/AstNode.php
+++ b/php/src/AstNode.php
@@ -31,12 +31,13 @@ final class AstNode
     /**
      * @template T of object
      *
-     * @param class-string<T> $_expectedType
+     * @param class-string<T> $expectedType
      *
      * @psalm-return list<T>
      */
-    public function getItems(string $_expectedType, RuleType $ruleType): array
+    public function getItems(string $expectedType, RuleType $ruleType): array
     {
+        $expectedType == 0; // Avoid error: Param #1 is never referenced in this method (see https://psalm.dev/135)
         $items = $this->subItems[$ruleType->name] ?? [];
 
         /**

--- a/php/src/GherkinParser.php
+++ b/php/src/GherkinParser.php
@@ -18,6 +18,8 @@ use Generator;
 
 /**
  * Parses a Gherkin document (or list of Source envelopes) and emits Cucumber Messages envelopes
+ *
+ * @psalm-api
  */
 final class GherkinParser
 {
@@ -28,13 +30,13 @@ final class GherkinParser
      * @param bool $predictableIds Ignored if IdGenerator is provided
      */
     public function __construct(
-        private readonly bool $predictableIds = false,
+        bool $predictableIds = false,
         private readonly bool $includeSource = true,
         private readonly bool $includeGherkinDocument = true,
         private readonly bool $includePickles = true,
         ?IdGenerator $idGenerator = null,
     ) {
-        $this->idGenerator = $idGenerator ?? ($this->predictableIds ? new IncrementingIdGenerator() : new UuidIdGenerator());
+        $this->idGenerator = $idGenerator ?? ($predictableIds ? new IncrementingIdGenerator() : new UuidIdGenerator());
         $this->pickleCompiler = new PickleCompiler($this->idGenerator);
     }
 

--- a/php/src/Location.php
+++ b/php/src/Location.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Cucumber\Gherkin;
 
+/**
+ * @psalm-api
+ */
 final class Location
 {
     public function __construct(

--- a/php/src/Parser/ParserTrait.php
+++ b/php/src/Parser/ParserTrait.php
@@ -72,12 +72,10 @@ trait ParserTrait
     /**
      * @template U
      * @param callable() : U $action
-     *
-     * @return U
      */
-    private function handleAstError(ParserContext $context, callable $action): mixed
+    private function handleAstError(ParserContext $context, callable $action): void
     {
-        return $this->handleExternalError($context, $action, null);
+        $this->handleExternalError($context, $action, null);
     }
 
     /**


### PR DESCRIPTION


### 🤔 What's changed?

This PR is an experiment run, to see if Psalm's "find unused" can be tamed, to become useful.

### ⚡️ What's your motivation? 

Psalm seems like a cool tool.

### 🏷️ What kind of change is this?


- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Is this a viable path?

I downgraded a Property in a constructor to a regular positional parameter – this was due to a Psalm warning. Is that reasonable?

One error handler dealt with return values, when it looked like that wasn't what it usually did. I turned it into a regular "callbacky" thing, instead.

Well, any thoughts around keeping these Psalm checks enabled would be welcome. Also thoughts around "why this does not suit Gherkin".

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
