### PR TITLE
php: Remove transitive php-parser dependency

### DIFF
--- a/php/composer.json
+++ b/php/composer.json
@@ -21,8 +21,7 @@
         "phpunit/phpunit": "^10.5",
         "vimeo/psalm": "5.19.1",
         "friendsofphp/php-cs-fixer": "^3.51",
-        "psalm/plugin-phpunit": "^0.19.0",
-        "nikic/php-parser": "^4.14"
+        "psalm/plugin-phpunit": "^0.19.0"
     },
     "repositories": [
         {


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Transitive dependencies do not need to be explicitly declared. Looks like this was originally added to resolve problems caused by using composer update --prefer-lowest that are no longer present.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
