### PR TITLE
Provide trailing space in Irish keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ## [Unreleased]
 ### Fixed
 - Provide trailing space in Irish keywords ([#243](https://github.com/cucumber/gherkin/pull/243))
+- Tamil "And" and "But" translations should have single trailing space ([#243](https://github.com/cucumber/gherkin/pull/243))
 
 ## [28.0.0] - 2024-02-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org).
 This document is formatted according to the principles of [Keep A CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- Provide trailing space in Irish keywords ([#243](https://github.com/cucumber/gherkin/pull/243))
 
 ## [28.0.0] - 2024-02-15
 ### Added

--- a/c/src/dialect.c
+++ b/c/src/dialect.c
@@ -1410,13 +1410,13 @@ static const Dialect fr_dialect = {
         &fr_then_keywords,
         &fr_when_keywords };
 
-static const wchar_t* const ga_and_KEYWORDS[] = { L"* ", L"Agus" };
+static const wchar_t* const ga_and_KEYWORDS[] = { L"* ", L"Agus " };
 static const Keywords ga_and_keywords = { 2, ga_and_KEYWORDS };
 
 static const wchar_t* const ga_background_KEYWORDS[] = { L"Cúlra" };
 static const Keywords ga_background_keywords = { 1, ga_background_KEYWORDS };
 
-static const wchar_t* const ga_but_KEYWORDS[] = { L"* ", L"Ach" };
+static const wchar_t* const ga_but_KEYWORDS[] = { L"* ", L"Ach " };
 static const Keywords ga_but_keywords = { 2, ga_but_KEYWORDS };
 
 static const wchar_t* const ga_examples_KEYWORDS[] = { L"Samplaí" };
@@ -1425,7 +1425,7 @@ static const Keywords ga_examples_keywords = { 1, ga_examples_KEYWORDS };
 static const wchar_t* const ga_feature_KEYWORDS[] = { L"Gné" };
 static const Keywords ga_feature_keywords = { 1, ga_feature_KEYWORDS };
 
-static const wchar_t* const ga_given_KEYWORDS[] = { L"* ", L"Cuir i gcás go", L"Cuir i gcás nach", L"Cuir i gcás gur", L"Cuir i gcás nár" };
+static const wchar_t* const ga_given_KEYWORDS[] = { L"* ", L"Cuir i gcás go ", L"Cuir i gcás nach ", L"Cuir i gcás gur ", L"Cuir i gcás nár " };
 static const Keywords ga_given_keywords = { 5, ga_given_KEYWORDS };
 
 static const wchar_t* const ga_rule_KEYWORDS[] = { L"Riail" };
@@ -1437,10 +1437,10 @@ static const Keywords ga_scenario_keywords = { 2, ga_scenario_KEYWORDS };
 static const wchar_t* const ga_scenarioOutline_KEYWORDS[] = { L"Cás Achomair" };
 static const Keywords ga_scenarioOutline_keywords = { 1, ga_scenarioOutline_KEYWORDS };
 
-static const wchar_t* const ga_then_KEYWORDS[] = { L"* ", L"Ansin" };
+static const wchar_t* const ga_then_KEYWORDS[] = { L"* ", L"Ansin " };
 static const Keywords ga_then_keywords = { 2, ga_then_KEYWORDS };
 
-static const wchar_t* const ga_when_KEYWORDS[] = { L"* ", L"Nuair a", L"Nuair nach", L"Nuair ba", L"Nuair nár" };
+static const wchar_t* const ga_when_KEYWORDS[] = { L"* ", L"Nuair a ", L"Nuair nach ", L"Nuair ba ", L"Nuair nár " };
 static const Keywords ga_when_keywords = { 5, ga_when_KEYWORDS };
 
 static const Dialect ga_dialect = {
@@ -3055,13 +3055,13 @@ static const Dialect sv_dialect = {
         &sv_then_keywords,
         &sv_when_keywords };
 
-static const wchar_t* const ta_and_KEYWORDS[] = { L"* ", L"மேலும்  ", L"மற்றும் " };
+static const wchar_t* const ta_and_KEYWORDS[] = { L"* ", L"மேலும் ", L"மற்றும் " };
 static const Keywords ta_and_keywords = { 3, ta_and_KEYWORDS };
 
 static const wchar_t* const ta_background_KEYWORDS[] = { L"பின்னணி" };
 static const Keywords ta_background_keywords = { 1, ta_background_KEYWORDS };
 
-static const wchar_t* const ta_but_KEYWORDS[] = { L"* ", L"ஆனால்  " };
+static const wchar_t* const ta_but_KEYWORDS[] = { L"* ", L"ஆனால் " };
 static const Keywords ta_but_keywords = { 2, ta_but_KEYWORDS };
 
 static const wchar_t* const ta_examples_KEYWORDS[] = { L"எடுத்துக்காட்டுகள்", L"காட்சிகள்", L"நிலைமைகளில்" };

--- a/cpp/src/lib/gherkin/cucumber/gherkin/dialect.cpp
+++ b/cpp/src/lib/gherkin/cucumber/gherkin/dialect.cpp
@@ -223,7 +223,7 @@ all_keywords()
             { "examples", { "Eksempler" } },
             { "feature", { "Egenskab" } },
             { "given", { "* ", "Givet " } },
-            { "rule", { "Rule" } },
+            { "rule", { "Regel" } },
             { "scenario", { "Eksempel", "Scenarie" } },
             { "scenarioOutline", { "Abstrakt Scenario" } },
             { "then", { "* ", "Så " } },
@@ -399,7 +399,7 @@ all_keywords()
             { "examples", { "Ekzemploj" } },
             { "feature", { "Trajto" } },
             { "given", { "* ", "Donitaĵo ", "Komence " } },
-            { "rule", { "Rule" } },
+            { "rule", { "Regulo" } },
             { "scenario", { "Ekzemplo", "Scenaro", "Kazo" } },
             { "scenarioOutline", { "Konturo de la scenaro", "Skizo", "Kazo-skizo" } },
             { "then", { "* ", "Do " } },
@@ -489,17 +489,17 @@ all_keywords()
     {
         "ga",
         {
-            { "and", { "* ", "Agus" } },
+            { "and", { "* ", "Agus " } },
             { "background", { "Cúlra" } },
-            { "but", { "* ", "Ach" } },
+            { "but", { "* ", "Ach " } },
             { "examples", { "Samplaí" } },
             { "feature", { "Gné" } },
-            { "given", { "* ", "Cuir i gcás go", "Cuir i gcás nach", "Cuir i gcás gur", "Cuir i gcás nár" } },
+            { "given", { "* ", "Cuir i gcás go ", "Cuir i gcás nach ", "Cuir i gcás gur ", "Cuir i gcás nár " } },
             { "rule", { "Riail" } },
             { "scenario", { "Sampla", "Cás" } },
             { "scenarioOutline", { "Cás Achomair" } },
-            { "then", { "* ", "Ansin" } },
-            { "when", { "* ", "Nuair a", "Nuair nach", "Nuair ba", "Nuair nár" } }
+            { "then", { "* ", "Ansin " } },
+            { "when", { "* ", "Nuair a ", "Nuair nach ", "Nuair ba ", "Nuair nár " } }
         }
     },
     {
@@ -649,7 +649,7 @@ all_keywords()
     {
         "it",
         {
-            { "and", { "* ", "E " } },
+            { "and", { "* ", "E ", "Ed " } },
             { "background", { "Contesto" } },
             { "but", { "* ", "Ma " } },
             { "examples", { "Esempi" } },
@@ -863,7 +863,7 @@ all_keywords()
             { "examples", { "Voorbeelden" } },
             { "feature", { "Functionaliteit" } },
             { "given", { "* ", "Gegeven ", "Stel " } },
-            { "rule", { "Rule" } },
+            { "rule", { "Regel" } },
             { "scenario", { "Voorbeeld", "Scenario" } },
             { "scenarioOutline", { "Abstract Scenario" } },
             { "then", { "* ", "Dan " } },
@@ -1049,9 +1049,9 @@ all_keywords()
     {
         "ta",
         {
-            { "and", { "* ", "மேலும்  ", "மற்றும் " } },
+            { "and", { "* ", "மேலும் ", "மற்றும் " } },
             { "background", { "பின்னணி" } },
-            { "but", { "* ", "ஆனால்  " } },
+            { "but", { "* ", "ஆனால் " } },
             { "examples", { "எடுத்துக்காட்டுகள்", "காட்சிகள்", "நிலைமைகளில்" } },
             { "feature", { "அம்சம்", "வணிக தேவை", "திறன்" } },
             { "given", { "* ", "கொடுக்கப்பட்ட " } },
@@ -1199,7 +1199,7 @@ all_keywords()
             { "examples", { "Dữ liệu" } },
             { "feature", { "Tính năng" } },
             { "given", { "* ", "Biết ", "Cho " } },
-            { "rule", { "Rule" } },
+            { "rule", { "Quy tắc" } },
             { "scenario", { "Tình huống", "Kịch bản" } },
             { "scenarioOutline", { "Khung tình huống", "Khung kịch bản" } },
             { "then", { "* ", "Thì " } },
@@ -1220,6 +1220,22 @@ all_keywords()
             { "scenarioOutline", { "场景大纲", "剧本大纲" } },
             { "then", { "* ", "那么" } },
             { "when", { "* ", "当" } }
+        }
+    },
+    {
+        "ml",
+        {
+            { "and", { "* ", "ഒപ്പം" } },
+            { "background", { "പശ്ചാത്തലം" } },
+            { "but", { "* ", "പക്ഷേ" } },
+            { "examples", { "ഉദാഹരണങ്ങൾ" } },
+            { "feature", { "സവിശേഷത" } },
+            { "given", { "* ", "നൽകിയത്" } },
+            { "rule", { "നിയമം" } },
+            { "scenario", { "രംഗം" } },
+            { "scenarioOutline", { "സാഹചര്യത്തിന്റെ രൂപരേഖ" } },
+            { "then", { "* ", "പിന്നെ" } },
+            { "when", { "എപ്പോൾ" } }
         }
     },
     {

--- a/dart/assets/gherkin-languages.json
+++ b/dart/assets/gherkin-languages.json
@@ -278,7 +278,7 @@
       "Nə vaxt ki "
     ]
   },
-    "be": {
+  "be": {
     "and": [
       "* ",
       "I ",
@@ -1401,14 +1401,14 @@
   "ga": {
     "and": [
       "* ",
-      "Agus"
+      "Agus "
     ],
     "background": [
       "Cúlra"
     ],
     "but": [
       "* ",
-      "Ach"
+      "Ach "
     ],
     "examples": [
       "Samplaí"
@@ -1418,10 +1418,10 @@
     ],
     "given": [
       "* ",
-      "Cuir i gcás go",
-      "Cuir i gcás nach",
-      "Cuir i gcás gur",
-      "Cuir i gcás nár"
+      "Cuir i gcás go ",
+      "Cuir i gcás nach ",
+      "Cuir i gcás gur ",
+      "Cuir i gcás nár "
     ],
     "name": "Irish",
     "native": "Gaeilge",
@@ -1437,14 +1437,14 @@
     ],
     "then": [
       "* ",
-      "Ansin"
+      "Ansin "
     ],
     "when": [
       "* ",
-      "Nuair a",
-      "Nuair nach",
-      "Nuair ba",
-      "Nuair nár"
+      "Nuair a ",
+      "Nuair nach ",
+      "Nuair ba ",
+      "Nuair nár "
     ]
   },
   "gj": {
@@ -3134,7 +3134,7 @@
   "ta": {
     "and": [
       "* ",
-      "மேலும்  ",
+      "மேலும் ",
       "மற்றும் "
     ],
     "background": [
@@ -3142,7 +3142,7 @@
     ],
     "but": [
       "* ",
-      "ஆனால்  "
+      "ஆனால் "
     ],
     "examples": [
       "எடுத்துக்காட்டுகள்",

--- a/dotnet/Gherkin/gherkin-languages.json
+++ b/dotnet/Gherkin/gherkin-languages.json
@@ -278,7 +278,7 @@
       "Nə vaxt ki "
     ]
   },
-    "be": {
+  "be": {
     "and": [
       "* ",
       "I ",
@@ -1401,14 +1401,14 @@
   "ga": {
     "and": [
       "* ",
-      "Agus"
+      "Agus "
     ],
     "background": [
       "Cúlra"
     ],
     "but": [
       "* ",
-      "Ach"
+      "Ach "
     ],
     "examples": [
       "Samplaí"
@@ -1418,10 +1418,10 @@
     ],
     "given": [
       "* ",
-      "Cuir i gcás go",
-      "Cuir i gcás nach",
-      "Cuir i gcás gur",
-      "Cuir i gcás nár"
+      "Cuir i gcás go ",
+      "Cuir i gcás nach ",
+      "Cuir i gcás gur ",
+      "Cuir i gcás nár "
     ],
     "name": "Irish",
     "native": "Gaeilge",
@@ -1437,14 +1437,14 @@
     ],
     "then": [
       "* ",
-      "Ansin"
+      "Ansin "
     ],
     "when": [
       "* ",
-      "Nuair a",
-      "Nuair nach",
-      "Nuair ba",
-      "Nuair nár"
+      "Nuair a ",
+      "Nuair nach ",
+      "Nuair ba ",
+      "Nuair nár "
     ]
   },
   "gj": {
@@ -3134,7 +3134,7 @@
   "ta": {
     "and": [
       "* ",
-      "மேலும்  ",
+      "மேலும் ",
       "மற்றும் "
     ],
     "background": [
@@ -3142,7 +3142,7 @@
     ],
     "but": [
       "* ",
-      "ஆனால்  "
+      "ஆனால் "
     ],
     "examples": [
       "எடுத்துக்காட்டுகள்",

--- a/elixir/priv/gherkin_languages.json
+++ b/elixir/priv/gherkin_languages.json
@@ -278,7 +278,7 @@
       "Nə vaxt ki "
     ]
   },
-    "be": {
+  "be": {
     "and": [
       "* ",
       "I ",
@@ -1401,14 +1401,14 @@
   "ga": {
     "and": [
       "* ",
-      "Agus"
+      "Agus "
     ],
     "background": [
       "Cúlra"
     ],
     "but": [
       "* ",
-      "Ach"
+      "Ach "
     ],
     "examples": [
       "Samplaí"
@@ -1418,10 +1418,10 @@
     ],
     "given": [
       "* ",
-      "Cuir i gcás go",
-      "Cuir i gcás nach",
-      "Cuir i gcás gur",
-      "Cuir i gcás nár"
+      "Cuir i gcás go ",
+      "Cuir i gcás nach ",
+      "Cuir i gcás gur ",
+      "Cuir i gcás nár "
     ],
     "name": "Irish",
     "native": "Gaeilge",
@@ -1437,14 +1437,14 @@
     ],
     "then": [
       "* ",
-      "Ansin"
+      "Ansin "
     ],
     "when": [
       "* ",
-      "Nuair a",
-      "Nuair nach",
-      "Nuair ba",
-      "Nuair nár"
+      "Nuair a ",
+      "Nuair nach ",
+      "Nuair ba ",
+      "Nuair nár "
     ]
   },
   "gj": {
@@ -3134,7 +3134,7 @@
   "ta": {
     "and": [
       "* ",
-      "மேலும்  ",
+      "மேலும் ",
       "மற்றும் "
     ],
     "background": [
@@ -3142,7 +3142,7 @@
     ],
     "but": [
       "* ",
-      "ஆனால்  "
+      "ஆனால் "
     ],
     "examples": [
       "எடுத்துக்காட்டுகள்",

--- a/gherkin-languages.json
+++ b/gherkin-languages.json
@@ -278,7 +278,7 @@
       "Nə vaxt ki "
     ]
   },
-    "be": {
+  "be": {
     "and": [
       "* ",
       "I ",
@@ -1401,14 +1401,14 @@
   "ga": {
     "and": [
       "* ",
-      "Agus"
+      "Agus "
     ],
     "background": [
       "Cúlra"
     ],
     "but": [
       "* ",
-      "Ach"
+      "Ach "
     ],
     "examples": [
       "Samplaí"
@@ -1418,10 +1418,10 @@
     ],
     "given": [
       "* ",
-      "Cuir i gcás go",
-      "Cuir i gcás nach",
-      "Cuir i gcás gur",
-      "Cuir i gcás nár"
+      "Cuir i gcás go ",
+      "Cuir i gcás nach ",
+      "Cuir i gcás gur ",
+      "Cuir i gcás nár "
     ],
     "name": "Irish",
     "native": "Gaeilge",
@@ -1437,14 +1437,14 @@
     ],
     "then": [
       "* ",
-      "Ansin"
+      "Ansin "
     ],
     "when": [
       "* ",
-      "Nuair a",
-      "Nuair nach",
-      "Nuair ba",
-      "Nuair nár"
+      "Nuair a ",
+      "Nuair nach ",
+      "Nuair ba ",
+      "Nuair nár "
     ]
   },
   "gj": {
@@ -3134,7 +3134,7 @@
   "ta": {
     "and": [
       "* ",
-      "மேலும்  ",
+      "மேலும் ",
       "மற்றும் "
     ],
     "background": [
@@ -3142,7 +3142,7 @@
     ],
     "but": [
       "* ",
-      "ஆனால்  "
+      "ஆனால் "
     ],
     "examples": [
       "எடுத்துக்காட்டுகள்",

--- a/go/dialects_builtin.go
+++ b/go/dialects_builtin.go
@@ -1960,53 +1960,53 @@ var builtinDialects = gherkinDialectMap{
 			},
 			given: {
 				"* ",
-				"Cuir i gcás go",
-				"Cuir i gcás nach",
-				"Cuir i gcás gur",
-				"Cuir i gcás nár",
+				"Cuir i gcás go ",
+				"Cuir i gcás nach ",
+				"Cuir i gcás gur ",
+				"Cuir i gcás nár ",
 			},
 			when: {
 				"* ",
-				"Nuair a",
-				"Nuair nach",
-				"Nuair ba",
-				"Nuair nár",
+				"Nuair a ",
+				"Nuair nach ",
+				"Nuair ba ",
+				"Nuair nár ",
 			},
 			then: {
 				"* ",
-				"Ansin",
+				"Ansin ",
 			},
 			and: {
 				"* ",
-				"Agus",
+				"Agus ",
 			},
 			but: {
 				"* ",
-				"Ach",
+				"Ach ",
 			},
 		},
 		map[string]messages.StepKeywordType{
-			"Cuir i gcás go": messages.StepKeywordType_CONTEXT,
+			"Cuir i gcás go ": messages.StepKeywordType_CONTEXT,
 
-			"Cuir i gcás nach": messages.StepKeywordType_CONTEXT,
+			"Cuir i gcás nach ": messages.StepKeywordType_CONTEXT,
 
-			"Cuir i gcás gur": messages.StepKeywordType_CONTEXT,
+			"Cuir i gcás gur ": messages.StepKeywordType_CONTEXT,
 
-			"Cuir i gcás nár": messages.StepKeywordType_CONTEXT,
+			"Cuir i gcás nár ": messages.StepKeywordType_CONTEXT,
 
-			"Nuair a": messages.StepKeywordType_ACTION,
+			"Nuair a ": messages.StepKeywordType_ACTION,
 
-			"Nuair nach": messages.StepKeywordType_ACTION,
+			"Nuair nach ": messages.StepKeywordType_ACTION,
 
-			"Nuair ba": messages.StepKeywordType_ACTION,
+			"Nuair ba ": messages.StepKeywordType_ACTION,
 
-			"Nuair nár": messages.StepKeywordType_ACTION,
+			"Nuair nár ": messages.StepKeywordType_ACTION,
 
-			"Ansin": messages.StepKeywordType_OUTCOME,
+			"Ansin ": messages.StepKeywordType_OUTCOME,
 
-			"Agus": messages.StepKeywordType_CONJUNCTION,
+			"Agus ": messages.StepKeywordType_CONJUNCTION,
 
-			"Ach": messages.StepKeywordType_CONJUNCTION,
+			"Ach ": messages.StepKeywordType_CONJUNCTION,
 
 			"* ": messages.StepKeywordType_UNKNOWN,
 		}},
@@ -4382,12 +4382,12 @@ var builtinDialects = gherkinDialectMap{
 			},
 			and: {
 				"* ",
-				"மேலும்  ",
+				"மேலும் ",
 				"மற்றும் ",
 			},
 			but: {
 				"* ",
-				"ஆனால்  ",
+				"ஆனால் ",
 			},
 		},
 		map[string]messages.StepKeywordType{
@@ -4397,11 +4397,11 @@ var builtinDialects = gherkinDialectMap{
 
 			"அப்பொழுது ": messages.StepKeywordType_OUTCOME,
 
-			"மேலும்  ": messages.StepKeywordType_CONJUNCTION,
+			"மேலும் ": messages.StepKeywordType_CONJUNCTION,
 
 			"மற்றும் ": messages.StepKeywordType_CONJUNCTION,
 
-			"ஆனால்  ": messages.StepKeywordType_CONJUNCTION,
+			"ஆனால் ": messages.StepKeywordType_CONJUNCTION,
 
 			"* ": messages.StepKeywordType_UNKNOWN,
 		}},

--- a/javascript/src/gherkin-languages.json
+++ b/javascript/src/gherkin-languages.json
@@ -278,7 +278,7 @@
       "Nə vaxt ki "
     ]
   },
-    "be": {
+  "be": {
     "and": [
       "* ",
       "I ",
@@ -1401,14 +1401,14 @@
   "ga": {
     "and": [
       "* ",
-      "Agus"
+      "Agus "
     ],
     "background": [
       "Cúlra"
     ],
     "but": [
       "* ",
-      "Ach"
+      "Ach "
     ],
     "examples": [
       "Samplaí"
@@ -1418,10 +1418,10 @@
     ],
     "given": [
       "* ",
-      "Cuir i gcás go",
-      "Cuir i gcás nach",
-      "Cuir i gcás gur",
-      "Cuir i gcás nár"
+      "Cuir i gcás go ",
+      "Cuir i gcás nach ",
+      "Cuir i gcás gur ",
+      "Cuir i gcás nár "
     ],
     "name": "Irish",
     "native": "Gaeilge",
@@ -1437,14 +1437,14 @@
     ],
     "then": [
       "* ",
-      "Ansin"
+      "Ansin "
     ],
     "when": [
       "* ",
-      "Nuair a",
-      "Nuair nach",
-      "Nuair ba",
-      "Nuair nár"
+      "Nuair a ",
+      "Nuair nach ",
+      "Nuair ba ",
+      "Nuair nár "
     ]
   },
   "gj": {
@@ -3134,7 +3134,7 @@
   "ta": {
     "and": [
       "* ",
-      "மேலும்  ",
+      "மேலும் ",
       "மற்றும் "
     ],
     "background": [
@@ -3142,7 +3142,7 @@
     ],
     "but": [
       "* ",
-      "ஆனால்  "
+      "ஆனால் "
     ],
     "examples": [
       "எடுத்துக்காட்டுகள்",

--- a/objective-c/GherkinLanguages/gherkin-languages.json
+++ b/objective-c/GherkinLanguages/gherkin-languages.json
@@ -278,6 +278,55 @@
       "Nə vaxt ki "
     ]
   },
+  "be": {
+    "and": [
+      "* ",
+      "I ",
+      "Ды ",
+      "Таксама "
+    ],
+    "background": [
+      "Кантэкст"
+    ],
+    "but": [
+      "* ",
+      "Але ",
+      "Інакш "
+    ],
+    "examples": [
+      "Прыклады"
+    ],
+    "feature": [
+      "Функцыянальнасць",
+      "Фіча"
+    ],
+    "given": [
+      "* ",
+      "Няхай ",
+      "Дадзена "
+    ],
+    "name": "Belarusian",
+    "native": "Беларуская",
+    "rule": [
+      "Правілы"
+    ],
+    "scenario": [
+      "Сцэнарый",
+      "Cцэнар"
+    ],
+    "scenarioOutline": [
+      "Шаблон сцэнарыя",
+      "Узор сцэнара"
+    ],
+    "then": [
+      "* ",
+      "Тады "
+    ],
+    "when": [
+      "* ",
+      "Калі "
+    ]
+  },
   "bg": {
     "and": [
       "* ",
@@ -581,7 +630,7 @@
     "name": "Danish",
     "native": "dansk",
     "rule": [
-      "Rule"
+      "Regel"
     ],
     "scenario": [
       "Eksempel",
@@ -1083,7 +1132,7 @@
     "name": "Esperanto",
     "native": "Esperanto",
     "rule": [
-      "Rule"
+      "Regulo"
     ],
     "scenario": [
       "Ekzemplo",
@@ -1352,14 +1401,14 @@
   "ga": {
     "and": [
       "* ",
-      "Agus"
+      "Agus "
     ],
     "background": [
       "Cúlra"
     ],
     "but": [
       "* ",
-      "Ach"
+      "Ach "
     ],
     "examples": [
       "Samplaí"
@@ -1369,10 +1418,10 @@
     ],
     "given": [
       "* ",
-      "Cuir i gcás go",
-      "Cuir i gcás nach",
-      "Cuir i gcás gur",
-      "Cuir i gcás nár"
+      "Cuir i gcás go ",
+      "Cuir i gcás nach ",
+      "Cuir i gcás gur ",
+      "Cuir i gcás nár "
     ],
     "name": "Irish",
     "native": "Gaeilge",
@@ -1388,14 +1437,14 @@
     ],
     "then": [
       "* ",
-      "Ansin"
+      "Ansin "
     ],
     "when": [
       "* ",
-      "Nuair a",
-      "Nuair nach",
-      "Nuair ba",
-      "Nuair nár"
+      "Nuair a ",
+      "Nuair nach ",
+      "Nuair ba ",
+      "Nuair nár "
     ]
   },
   "gj": {
@@ -1837,7 +1886,8 @@
   "it": {
     "and": [
       "* ",
-      "E "
+      "E ",
+      "Ed "
     ],
     "background": [
       "Contesto"
@@ -2483,7 +2533,7 @@
     "name": "Dutch",
     "native": "Nederlands",
     "rule": [
-      "Rule"
+      "Regel"
     ],
     "scenario": [
       "Voorbeeld",
@@ -3084,7 +3134,7 @@
   "ta": {
     "and": [
       "* ",
-      "மேலும்  ",
+      "மேலும் ",
       "மற்றும் "
     ],
     "background": [
@@ -3092,7 +3142,7 @@
     ],
     "but": [
       "* ",
-      "ஆனால்  "
+      "ஆனால் "
     ],
     "examples": [
       "எடுத்துக்காட்டுகள்",
@@ -3526,7 +3576,7 @@
     "name": "Vietnamese",
     "native": "Tiếng Việt",
     "rule": [
-      "Rule"
+      "Quy tắc"
     ],
     "scenario": [
       "Tình huống",
@@ -3592,6 +3642,47 @@
     "when": [
       "* ",
       "当"
+    ]
+  },
+  "ml": {
+    "and": [
+      "* ",
+      "ഒപ്പം"
+    ],
+    "background": [
+      "പശ്ചാത്തലം"
+    ],
+    "but": [
+      "* ",
+      "പക്ഷേ"
+    ],
+    "examples": [
+      "ഉദാഹരണങ്ങൾ"
+    ],
+    "feature": [
+      "സവിശേഷത"
+    ],
+    "given": [
+      "* ",
+      "നൽകിയത്"
+    ],
+    "name": "Malayalam",
+    "native": "മലയാളം",
+    "rule": [
+      "നിയമം"
+    ],
+    "scenario": [
+      "രംഗം"
+    ],
+    "scenarioOutline": [
+      "സാഹചര്യത്തിന്റെ രൂപരേഖ"
+    ],
+    "then": [
+      "* ",
+      "പിന്നെ"
+    ],
+    "when": [
+      "എപ്പോൾ"
     ]
   },
   "zh-TW": {

--- a/php/resources/gherkin-languages.json
+++ b/php/resources/gherkin-languages.json
@@ -278,7 +278,7 @@
       "Nə vaxt ki "
     ]
   },
-    "be": {
+  "be": {
     "and": [
       "* ",
       "I ",
@@ -1401,14 +1401,14 @@
   "ga": {
     "and": [
       "* ",
-      "Agus"
+      "Agus "
     ],
     "background": [
       "Cúlra"
     ],
     "but": [
       "* ",
-      "Ach"
+      "Ach "
     ],
     "examples": [
       "Samplaí"
@@ -1418,10 +1418,10 @@
     ],
     "given": [
       "* ",
-      "Cuir i gcás go",
-      "Cuir i gcás nach",
-      "Cuir i gcás gur",
-      "Cuir i gcás nár"
+      "Cuir i gcás go ",
+      "Cuir i gcás nach ",
+      "Cuir i gcás gur ",
+      "Cuir i gcás nár "
     ],
     "name": "Irish",
     "native": "Gaeilge",
@@ -1437,14 +1437,14 @@
     ],
     "then": [
       "* ",
-      "Ansin"
+      "Ansin "
     ],
     "when": [
       "* ",
-      "Nuair a",
-      "Nuair nach",
-      "Nuair ba",
-      "Nuair nár"
+      "Nuair a ",
+      "Nuair nach ",
+      "Nuair ba ",
+      "Nuair nár "
     ]
   },
   "gj": {
@@ -3134,7 +3134,7 @@
   "ta": {
     "and": [
       "* ",
-      "மேலும்  ",
+      "மேலும் ",
       "மற்றும் "
     ],
     "background": [
@@ -3142,7 +3142,7 @@
     ],
     "but": [
       "* ",
-      "ஆனால்  "
+      "ஆனால் "
     ],
     "examples": [
       "எடுத்துக்காட்டுகள்",

--- a/python/gherkin/gherkin-languages.json
+++ b/python/gherkin/gherkin-languages.json
@@ -278,7 +278,7 @@
       "Nə vaxt ki "
     ]
   },
-    "be": {
+  "be": {
     "and": [
       "* ",
       "I ",
@@ -1401,14 +1401,14 @@
   "ga": {
     "and": [
       "* ",
-      "Agus"
+      "Agus "
     ],
     "background": [
       "Cúlra"
     ],
     "but": [
       "* ",
-      "Ach"
+      "Ach "
     ],
     "examples": [
       "Samplaí"
@@ -1418,10 +1418,10 @@
     ],
     "given": [
       "* ",
-      "Cuir i gcás go",
-      "Cuir i gcás nach",
-      "Cuir i gcás gur",
-      "Cuir i gcás nár"
+      "Cuir i gcás go ",
+      "Cuir i gcás nach ",
+      "Cuir i gcás gur ",
+      "Cuir i gcás nár "
     ],
     "name": "Irish",
     "native": "Gaeilge",
@@ -1437,14 +1437,14 @@
     ],
     "then": [
       "* ",
-      "Ansin"
+      "Ansin "
     ],
     "when": [
       "* ",
-      "Nuair a",
-      "Nuair nach",
-      "Nuair ba",
-      "Nuair nár"
+      "Nuair a ",
+      "Nuair nach ",
+      "Nuair ba ",
+      "Nuair nár "
     ]
   },
   "gj": {
@@ -3134,7 +3134,7 @@
   "ta": {
     "and": [
       "* ",
-      "மேலும்  ",
+      "மேலும் ",
       "மற்றும் "
     ],
     "background": [
@@ -3142,7 +3142,7 @@
     ],
     "but": [
       "* ",
-      "ஆனால்  "
+      "ஆனால் "
     ],
     "examples": [
       "எடுத்துக்காட்டுகள்",

--- a/ruby/lib/gherkin/gherkin-languages.json
+++ b/ruby/lib/gherkin/gherkin-languages.json
@@ -278,7 +278,7 @@
       "Nə vaxt ki "
     ]
   },
-    "be": {
+  "be": {
     "and": [
       "* ",
       "I ",
@@ -1401,14 +1401,14 @@
   "ga": {
     "and": [
       "* ",
-      "Agus"
+      "Agus "
     ],
     "background": [
       "Cúlra"
     ],
     "but": [
       "* ",
-      "Ach"
+      "Ach "
     ],
     "examples": [
       "Samplaí"
@@ -1418,10 +1418,10 @@
     ],
     "given": [
       "* ",
-      "Cuir i gcás go",
-      "Cuir i gcás nach",
-      "Cuir i gcás gur",
-      "Cuir i gcás nár"
+      "Cuir i gcás go ",
+      "Cuir i gcás nach ",
+      "Cuir i gcás gur ",
+      "Cuir i gcás nár "
     ],
     "name": "Irish",
     "native": "Gaeilge",
@@ -1437,14 +1437,14 @@
     ],
     "then": [
       "* ",
-      "Ansin"
+      "Ansin "
     ],
     "when": [
       "* ",
-      "Nuair a",
-      "Nuair nach",
-      "Nuair ba",
-      "Nuair nár"
+      "Nuair a ",
+      "Nuair nach ",
+      "Nuair ba ",
+      "Nuair nár "
     ]
   },
   "gj": {
@@ -3134,7 +3134,7 @@
   "ta": {
     "and": [
       "* ",
-      "மேலும்  ",
+      "மேலும் ",
       "மற்றும் "
     ],
     "background": [
@@ -3142,7 +3142,7 @@
     ],
     "but": [
       "* ",
-      "ஆனால்  "
+      "ஆனால் "
     ],
     "examples": [
       "எடுத்துக்காட்டுகள்",


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

- Spaces are used at the end of step keywords e.g. `Given ` and have been applied to the Irish translation
- Applied translations that were partially applied across language implementations

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

- As spaces were missing, and with the language server using the official gherkin parser; steps were incorrectly marked undefined when a step was introduced between the step keyword and the step text; as the space was being considered part of the step text, instead of typically part of the step keyword. This resolves that issue
- Ensure language translations are fully aligned and up to date

<img width="98" alt="Screenshot 2024-04-10 at 22 11 33" src="https://github.com/cucumber/gherkin/assets/5904340/19dec9c6-ecc4-4273-92fe-0ef1207c1f2b">

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
