### PR TITLE
fix(cpp): handle download failures and don't use GitHub api to get latest releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ### Fixed
 - Provide trailing space in Irish keywords ([#243](https://github.com/cucumber/gherkin/pull/243))
 - Tamil "And" and "But" translations should have single trailing space ([#243](https://github.com/cucumber/gherkin/pull/243))
+- Intermittent failure of cpp test jobs in CI ([#217](https://github.com/cucumber/gherkin/issues/217))
 
 ## [28.0.0] - 2024-02-15
 ### Added

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,6 +9,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    add_compile_definitions(_CRT_SECURE_NO_WARNINGS _SCL_SECURE_NO_WARNINGS)
+endif()
+
 find_package(nlohmann_json CONFIG REQUIRED)
 find_package(cucumber_messages CONFIG REQUIRED)
 

--- a/cpp/cmake/cmate
+++ b/cpp/cmake/cmate
@@ -47,6 +47,10 @@ function(cmate_setgdir VAR VAL)
     file(MAKE_DIRECTORY ${${VAR}})
 endfunction()
 
+function(cmate_sleep DURATION)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E sleep ${DURATION})
+endfunction()
+
 function(cmate_load_version)
     if(NOT "${CMATE_VERSION}" STREQUAL "")
         return()
@@ -176,15 +180,37 @@ endfunction()
 function(cmate_download URL FILE)
     if(CMATE_SIMULATE)
         cmate_msg("download ${URL} to ${FILE}")
-    else()
+        return()
+    endif()
+
+    set(WAIT_INTERVAL 5)
+    set(MAX_RETRIES 10)
+    set(RETRIES ${MAX_RETRIES})
+
+    cmate_msg("downloading ${URL}")
+
+    while(1)
         file(DOWNLOAD ${URL} ${FILE} STATUS ST)
-    endif()
 
-    list(GET ST 0 RC)
+        list(GET ST 0 RC)
 
-    if(RC)
-        cmate_die("download of ${URL} failed: ${ST}")
-    endif()
+        if(RC)
+            if(RETRIES GREATER 1)
+                math(EXPR RETRIES "${RETRIES} - 1")
+                math(EXPR ATTEMPT "${MAX_RETRIES} - ${RETRIES}")
+                cmate_msg(
+                    "download of ${URL} failed"
+                    " (attempt ${ATTEMPT} of ${MAX_RETRIES}"
+                    ", retrying in ${WAIT_INTERVAL}s)"
+                )
+                cmate_sleep(${WAIT_INTERVAL})
+            else()
+                cmate_die("download of ${URL} failed: ${ST}")
+            endif()
+        else()
+            break()
+        endif()
+    endwhile()
 endfunction()
 
 function(cmate_set_build_type RELEASE_FLAG_VAR)
@@ -202,41 +228,16 @@ function(cmate_set_build_type RELEASE_FLAG_VAR)
     cmate_setg(CMATE_BUILD_DIR "${CMATE_BUILD_BASE_DIR}/${TDIR}")
 endfunction()
 
-function(cmate_github_get_latest REPO VAR RE)
-    set(URL "https://api.github.com/repos/${REPO}/releases/latest")
-    set(TDIR "${CMATE_TMP_DIR}/${REPO}")
-    set(INFO "${TDIR}/info.json")
+function(cmate_github_get_latest REPO PKG VAR)
+    set(URL "https://github.com/${REPO}/releases/latest/download/${PKG}")
 
-    if (NOT EXISTS ${INFO})
-        file(MAKE_DIRECTORY ${TDIR})
-        cmate_download(${URL} ${INFO})
+    set(FILE "${CMATE_DL_DIR}/${PKG}")
+
+    if (NOT EXISTS ${FILE})
+        cmate_download(${URL} ${FILE})
     endif()
 
-    file(READ ${INFO} VINFO)
-    cmate_json_get_array(${VINFO} "assets" ASSETS)
-
-    foreach(ASSET ${ASSETS})
-        string(
-            JSON
-            BDURL
-            ERROR_VARIABLE ERR
-            GET "${ASSET}" "browser_download_url"
-        )
-
-        if(NOT ERR AND ${BDURL} MATCHES ${RE})
-            string(JSON FILE GET "${ASSET}" "name")
-            set(FILE "${CMATE_DL_DIR}/${FILE}")
-
-            if (NOT EXISTS ${FILE})
-                cmate_download(${BDURL} ${FILE})
-            endif()
-
-            set(${VAR} ${FILE} PARENT_SCOPE)
-            break()
-        endif()
-    endforeach()
-
-    file(REMOVE_RECURSE ${TDIR})
+    set(${VAR} ${FILE} PARENT_SCOPE)
 endfunction()
 
 function(cmate_check_ninja VAR)
@@ -259,11 +260,7 @@ function(cmate_check_ninja VAR)
         endif()
 
         if(NOT EXISTS "${CMATE_ENV_BIN_DIR}/${NCMD}")
-            cmate_github_get_latest(
-                "ninja-build/ninja"
-                NZIP
-                "ninja-${NOS}.zip$"
-            )
+            cmate_github_get_latest("ninja-build/ninja" "ninja-${NOS}.zip" NZIP)
 
             file(REMOVE_RECURSE ${TDIR})
             file(ARCHIVE_EXTRACT INPUT ${NZIP} DESTINATION ${TDIR})


### PR DESCRIPTION
### 🤔 What's changed?

- Added build code to handle failures while downloading tools and/or dependencies

### ⚡️ What's your motivation? 

- Fixes #217

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)
