### PR TITLE
[.NET] - AstMessagesConverter to return a default Location of (0,0) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 - [Ruby] Upgraded messages support to permit up to v26
 - [.NET] Drop unsupported frameworks. Now supported target frameworks are .NET 8, .NET Framework 4.6.2, .NET Standard 2.0
 - [.NET] Adopt File Scoped Namespaces c# feature
+- [.NET] Modified the AstConverter to return a Location(0,0) when the AST does not contain a Location for dynamically generated Examples tables
 
 ## [29.0.0] - 2024-08-12
 ### Added

--- a/dotnet/Gherkin/CucumberMessages/AstMessagesConverter.cs
+++ b/dotnet/Gherkin/CucumberMessages/AstMessagesConverter.cs
@@ -74,6 +74,9 @@ public class AstMessagesConverter
 
     private static Location ConvertLocation(Ast.Location location)
     {
+        // In Reqnroll and SpecFlow, plugins may provide dynamically created Example data rows that don't have source locations. Hard-coding these to (0, 0).
+        if (location == null)
+            return new Location(0, 0);
         return new Location(location.Column, location.Line);
     }
 


### PR DESCRIPTION
when the AST does not include a location for an element

I

### 🤔 What's changed?

<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

n Reqnroll and SpecFlow, plugins may provide dynamically created Example data rows that don't have source locations. Hard-coding these to (0, 0).



### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?



### 📋 Checklist:



- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ X] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [X ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
