### PR TITLE
Add support for .NET Framework 4.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 - [PHP, Java, Ruby, JavaScript] update dependency messages up to v26
 - [Python] Added type annotations ([#283](https://github.com/cucumber/gherkin/pull/283))
 - [Python] Switch to pyproject.toml ([#290](https://github.com/cucumber/gherkin/pull/290))
+- [.NET] Add Support for .NET Framework 4.7.2 [#300](https://github.com/cucumber/gherkin/pull/300)
 
 ### Changed
 - [.NET] Drop unsupported frameworks. Now supported target frameworks are .NET 8, .NET Standard 2.0 ([#265](https://github.com/cucumber/gherkin/pull/265))

--- a/dotnet/Gherkin.Specs/CLI/Program.cs
+++ b/dotnet/Gherkin.Specs/CLI/Program.cs
@@ -1,8 +1,7 @@
 using Gherkin.CucumberMessages;
 using Gherkin.Specs.EventStubs;
 using Gherkin.Specs.Tokens;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Gherkin.Specs.CLI;
 
@@ -100,11 +99,7 @@ class Program
         {
             foreach (var evt in gherkinEventsProvider.GetEvents(sourceEventEvent))
             {
-                var jsonString = JsonSerializer.Serialize(evt, new JsonSerializerOptions(JsonSerializerDefaults.Web)
-                {
-                    Converters = { new JsonStringEnumConverter() },
-                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-                });
+                var jsonString = JsonConvert.SerializeObject(evt);
                 Console.WriteLine(jsonString);
             }
         }

--- a/dotnet/Gherkin.Specs/DependencyValidationTests.cs
+++ b/dotnet/Gherkin.Specs/DependencyValidationTests.cs
@@ -1,6 +1,6 @@
 #if NETFRAMEWORK
 using System.Reflection;
-using System.Text.Json;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Gherkin.Specs;
@@ -15,7 +15,7 @@ public sealed class DependencyValidationTests
 
         var version = typeof(JsonSerializer).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
 
-        Assert.Equal("6.0.3524.45918", version); // System.Text.Json Version 6.0.10
+        Assert.Equal("13.0.3.27908", version); // System.Text.Json Version 6.0.10
     }
 }
 #endif

--- a/dotnet/Gherkin.Specs/Gherkin.Specs.csproj
+++ b/dotnet/Gherkin.Specs/Gherkin.Specs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <StartupObject>Gherkin.Specs.CLI.Program</StartupObject>
   </PropertyGroup>

--- a/dotnet/Gherkin.Specs/Helper/NDJsonParser.cs
+++ b/dotnet/Gherkin.Specs/Helper/NDJsonParser.cs
@@ -1,6 +1,4 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
+using Newtonsoft.Json;
 
 namespace Gherkin.Specs.Helper;
 
@@ -14,13 +12,7 @@ public class NDJsonParser
 
         foreach (var line in lines)
         {
-            var deserializedObject = JsonSerializer.Deserialize<T>(line, new JsonSerializerOptions(JsonSerializerDefaults.Web)
-            {
-                Converters =
-                {
-                    new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)
-                }
-            });
+            var deserializedObject = JsonConvert.DeserializeObject<T>(line);
             result.Add(deserializedObject);
         }
 

--- a/dotnet/Gherkin.sln
+++ b/dotnet/Gherkin.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7083F2CC-7F1D-40A3-8DF4-D16C090FF977}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		..\CHANGELOG.md = ..\CHANGELOG.md
 		Directory.Build.props = Directory.Build.props
 		bin\gherkin = bin\gherkin
 		gherkin-csharp.razor = gherkin-csharp.razor

--- a/dotnet/Gherkin/Gherkin.csproj
+++ b/dotnet/Gherkin/Gherkin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0;net472</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>
     <Deterministic Condition="'$(Configuration)' == 'Release'">false</Deterministic>

--- a/dotnet/Gherkin/Gherkin.csproj
+++ b/dotnet/Gherkin/Gherkin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>
     <Deterministic Condition="'$(Configuration)' == 'Release'">false</Deterministic>

--- a/dotnet/Gherkin/Gherkin.csproj
+++ b/dotnet/Gherkin/Gherkin.csproj
@@ -48,4 +48,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/dotnet/Gherkin/GherkinDialectProvider.cs
+++ b/dotnet/Gherkin/GherkinDialectProvider.cs
@@ -1,6 +1,5 @@
 using Gherkin.Ast;
-using System.Text.Json;
-
+using Newtonsoft.Json;
 namespace Gherkin;
 
 public interface IGherkinDialectProvider
@@ -52,7 +51,7 @@ public class GherkinDialectProvider : IGherkinDialectProvider
 
     protected virtual Dictionary<string, GherkinLanguageSetting> ParseJsonContent(string languagesFileContent)
     {
-        return JsonSerializer.Deserialize<Dictionary<string, GherkinLanguageSetting>>(languagesFileContent, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        return JsonConvert.DeserializeObject<Dictionary<string, GherkinLanguageSetting>>(languagesFileContent);
     }
 
     protected virtual bool TryGetDialect(string language, Dictionary<string, GherkinLanguageSetting> gherkinLanguageSettings, Location location, out GherkinDialect dialect)


### PR DESCRIPTION
### 🤔 What's changed?

This Pull request adds support for legacy .NET Framework 4.7.2 apps such as Unity, Godot 3 and more. 

It is a simple fix by using the `Newtonsoft.Json` nuget package for serializing and deserializing Json strings.

### ⚡️ What's your motivation? 

I love using Gherkin for Unit Testing, but it doesn't work in my Godot 3 project.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] My change requires a change to the documentation.
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
 - [x] I've changed the behaviour of the code
   - [x] I have added/updated tests to cover my changes.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
