### PR TITLE
Python: Replace publish action

### DIFF
--- a/.github/workflows/release-pypi.yaml
+++ b/.github/workflows/release-pypi.yaml
@@ -26,6 +26,10 @@ jobs:
       - name: Show Python version
         run: python --version
 
-      - uses: cucumber/action-publish-pypi@v3.0.0
-        with:
-          working-directory: "python"
+      - name: Install Python package dependencies
+        run: |
+          python -m pip install build twine
+          python -m build
+          twine check --strict dist/*
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -50,9 +50,11 @@ jobs:
         run: python --version
       - name: Install Python package dependencies
         run: |
-          python -m pip install -U pip setuptools wheel
-          pip install -U -r requirements.txt
+          python -m pip install build twine pip setuptools wheel
+          pip install -r requirements.txt
           pip install -e .
+          python -m build
+          twine check --strict dist/*
       - name: Run tests
         run: pytest
 


### PR DESCRIPTION
### 🤔 What's changed?

Replaces `cucumber/action-publish-pypi` with
`pypa/gh-action-pypi-publish@release/v1`. The motivation for using actions in the cucumber org is to ensure that we do not hand release tokens to untrusted code. As the party publishing our python packages, the Python Package Authority can be trusted. Additionally, their action uses trusted publishers which authorizes GitHub with OIDC so no long-lived tokens are used.


### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
