### PR TITLE
c: Stop passing -C to ctest

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -102,7 +102,7 @@ add_custom_command(
     TARGET gherkinexe
     COMMENT "Run tests"
     POST_BUILD
-    COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIGURATION>
+    COMMAND ${CMAKE_CTEST_COMMAND}
 )
 ############ Installation section ############
 set(include_install_dir "include")


### PR DESCRIPTION
The CONFIGURATION variable is unset, and passing -C without a value breaks with cmake 3.31.0.

<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

Remove an unused `-C` option from `ctest`.

### ⚡️ What's your motivation? 

Passing `-C` to `ctest` without a value (as happens because `CONFIGURATION` is unset) is useless before cmake 3.31.0, but breaks beginning with cmake 3.31.0
<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
