### PR TITLE
java: require all GherkinDialect properties to be non-null

### DIFF
--- a/java/src/main/java/io/cucumber/gherkin/GherkinDialect.java
+++ b/java/src/main/java/io/cucumber/gherkin/GherkinDialect.java
@@ -6,8 +6,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
 
 public final class GherkinDialect {
     private final String language;
@@ -28,20 +30,20 @@ public final class GherkinDialect {
     private final Map<String, List<StepKeywordType>> stepKeywordsTypes;
 
     GherkinDialect(String language, String name, String nativeName, List<String> featureKeywords, List<String> ruleKeywords, List<String> scenarioKeywords, List<String> scenarioOutlineKeywords, List<String> backgroundKeywords, List<String> examplesKeywords, List<String> givenKeywords, List<String> whenKeywords, List<String> thenKeywords, List<String> andKeywords, List<String> butKeywords) {
-        this.language = language;
-        this.name = name;
-        this.nativeName = nativeName;
-        this.featureKeywords = featureKeywords;
-        this.ruleKeywords = ruleKeywords;
-        this.scenarioKeywords = scenarioKeywords;
-        this.scenarioOutlineKeywords = scenarioOutlineKeywords;
-        this.backgroundKeywords = backgroundKeywords;
-        this.examplesKeywords = examplesKeywords;
-        this.givenKeywords = givenKeywords;
-        this.whenKeywords = whenKeywords;
-        this.thenKeywords = thenKeywords;
-        this.andKeywords = andKeywords;
-        this.butKeywords = butKeywords;
+        this.language = requireNonNull(language);
+        this.name = requireNonNull(name);
+        this.nativeName = requireNonNull(nativeName);
+        this.featureKeywords = requireNonNull(featureKeywords);
+        this.ruleKeywords = requireNonNull(ruleKeywords);
+        this.scenarioKeywords = requireNonNull(scenarioKeywords);
+        this.scenarioOutlineKeywords = requireNonNull(scenarioOutlineKeywords);
+        this.backgroundKeywords = requireNonNull(backgroundKeywords);
+        this.examplesKeywords = requireNonNull(examplesKeywords);
+        this.givenKeywords = requireNonNull(givenKeywords);
+        this.whenKeywords = requireNonNull(whenKeywords);
+        this.thenKeywords = requireNonNull(thenKeywords);
+        this.andKeywords = requireNonNull(andKeywords);
+        this.butKeywords = requireNonNull(butKeywords);
 
         List<String> stepKeywords = new ArrayList<>();
         stepKeywords.addAll(givenKeywords);


### PR DESCRIPTION
### 🤔 What's changed?

While the code generation and package private constructor already ensure that all fields are non-null, it is good to have this explicitly enforced in the code.


### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
