### PR TITLE
ci: Pin `.Net` and code generation test workflows to `ubuntu-22.04`

### DIFF
--- a/.github/workflows/release-nuget.yaml
+++ b/.github/workflows/release-nuget.yaml
@@ -8,7 +8,8 @@ on:
 jobs:
   publish-nuget:
     name: Publish package to NuGet.org
-    runs-on: ubuntu-latest
+    # Failing on `ubuntu-24.04` (https://github.com/cucumber/gherkin/issues/349)
+    runs-on: ubuntu-22.04
     environment: Release
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-codegen.yml
+++ b/.github/workflows/test-codegen.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   test-codegen:
-    runs-on: ubuntu-latest
+    # Failing on `ubuntu-24.04` (https://github.com/cucumber/gherkin/issues/349)
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -20,7 +20,8 @@ on:
 
 jobs:
   test-dotnet:
-    runs-on: ubuntu-latest
+    # Failing on `ubuntu-24.04` (https://github.com/cucumber/gherkin/issues/349)
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4


### PR DESCRIPTION
### 🤔 What's changed?

- Pin runner image to `ubuntu-22.04` on .Net and codegen workflows

### ⚡️ What's your motivation? 

- Reinstate workflows and enable passing pipelines - as code generation and `.NET` test workflows are incompatible with `ubuntu-24.04` - which is now `ubuntu-latest` (see #349) - and are failing

    ```bash
    $ Run dotnet tool update Berp --version 1.3.0 --tool-path ~/bin
    No usable version of libssl was found
    ```

#349 opened to resolve `ubuntu-24.04` incompatibility.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

NA.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)