### PR TITLE
chore(deps): update dependency berp to v1.5.0

### DIFF
--- a/.github/workflows/test-codegen.yml
+++ b/.github/workflows/test-codegen.yml
@@ -12,19 +12,18 @@ on:
 
 jobs:
   test-codegen:
-    # Failing on `ubuntu-24.04` (https://github.com/cucumber/gherkin/issues/349)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '8.0.x'
 
       - name: install berp
         run: |
-          dotnet tool update Berp --version 1.3.0 --tool-path ~/bin
+          dotnet tool update Berp --version 1.5.0 --tool-path ~/bin
           echo "~/bin" >> $GITHUB_PATH
 
       - name: generate code for all languages

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # See CONTRIBUTING.md
 #
-FROM mcr.microsoft.com/dotnet/sdk:7.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -19,7 +19,7 @@ WORKDIR /app
 RUN dotnet --list-sdks
 
 # Install Berp (dotnet tool installs are user-global; not system global)
-RUN dotnet tool install --global Berp --version 1.4.0 \
+RUN dotnet tool install --global Berp --version 1.5.0 \
       && echo 'export PATH="$PATH:/root/.dotnet/tools"' >> ~/.bashrc
 
 WORKDIR /app


### PR DESCRIPTION
### 🤔 What's changed?

- Bump `berp` from `v1.3.0` -> `v.1.5.0` in [codegen workflow](https://github.com/cucumber/gherkin/blob/e20af1911050d16f1d74df0190c8dedec34c4d10/.github/workflows/test-codegen.yml)
- Bump `berp` from `v1.4.0` -> `v1.5.0` in [parser generator Dockerfile](https://github.com/cucumber/gherkin/blob/e20af1911050d16f1d74df0190c8dedec34c4d10/Dockerfile)
- Bump `.NET` to `v8` from `v5` in code generation workflow and from `v7` in test generation workflow
- Bump `ubuntu-22.04` codegen workflow runner to `ubuntu-latest`

#### Release Notes

<details>
<summary><a href="https://github.com/gasparnagy/berp">gasparnagy/berp</a></summary>

##### [`v1.5.0`](https://github.com/gasparnagy/berp/blob/5b6664034769bfdd5b3a11eb3daf274d47f1b065/CHANGELOG.md#v150-2024-09-11)

- Added support for .NET 8.0
- Removed support for .NET 7.0 (end of framework support reached)

##### [`v1.4.0`](https://github.com/gasparnagy/berp/releases/tag/v1.4.0)

- Fix: --version should exit with status 0 (https://github.com/gasparnagy/berp/issues/18)
- Replaced .NET 5 platform with .NET 6 and .NET 7. It now works with any of these. (https://github.com/gasparnagy/berp/issues/17)
- Fix: Wrong lookahead in sample grammar (https://github.com/gasparnagy/berp/pull/16)
- Improved default Java razor file (https://github.com/gasparnagy/berp/pull/14)
</details>

### ⚡️ What's your motivation? 

- Contributes towards resolving #349
- Ensures code generation run locally matches workflow code generation

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

- Omitted a changelog entry being an internal change - with matching generated parser code. Though observe CHANGELOG reference in earlier release (see [19.0.2](https://github.com/cucumber/gherkin/blob/e20af1911050d16f1d74df0190c8dedec34c4d10/CHANGELOG.md#1902---2021-05-19) and that may want to include if there are use cases submoduling or interacting with the Dockerfile. Interested in thoughts.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)