### PR TITLE
Additional error handling edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 - [.NET] Fix NuGet package generation
+- [c] Optimise error handling for empty datatable rows
 
 ## [31.0.0] - 2025-01-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ### Fixed
 - [.NET] Fix NuGet package generation
 - [c] Optimise error handling for empty datatable rows
+- [Perl] Optimise error handling for unclosed DocStrings
 
 ## [31.0.0] - 2025-01-29
 ### Added

--- a/c/src/gherkin_line.c
+++ b/c/src/gherkin_line.c
@@ -76,17 +76,22 @@ wchar_t* GherkinLine_copy_line_text(const GherkinLine* line, int indent_to_remov
 
 const Items* GherkinLine_table_cells(const GherkinLine* line) {
     int item_count = calculate_cell_count(line->trimmed_line);
-    if (item_count == 0)
-        return (Items*)0;
+    Items* item_array = (Items*)malloc(sizeof(Items));
+    item_array->count = item_count;
+
+    if (item_count == 0) {
+        item_array->items = 0;
+        return item_array;
+    }
+
     Span* items = (Span*)malloc(item_count * sizeof(Span));
     int i;
     for (i = 0; i < item_count; ++i) {
         items[i].column = 0;
         items[i].text = 0;
     }
-    Items* item_array = (Items*)malloc(sizeof(Items));
-    item_array->count = item_count;
     item_array->items = items;
+
     const wchar_t* current_pos = line->trimmed_line;
     for (i = 0; i < item_count; ++i) {
         current_pos = populate_cell_data(&items[i], current_pos, current_pos - line->line_text);

--- a/perl/lib/Gherkin/TokenMatcher.pm
+++ b/perl/lib/Gherkin/TokenMatcher.pm
@@ -238,6 +238,9 @@ sub match_StepLine {
 
 sub match_DocStringSeparator {
     my ( $self, $token ) = @_;
+    if ($token->is_eof) {
+        return 0;
+    }
     if ( !$self->_active_doc_string_separator ) {
         return $self->_match_DocStringSeparator( $token, '"""', 1 )
           || $self->_match_DocStringSeparator( $token, '```', 1 );

--- a/testdata/bad/backslash_at_end_of_line_in_datatable.feature
+++ b/testdata/bad/backslash_at_end_of_line_in_datatable.feature
@@ -1,0 +1,5 @@
+Feature: Addition
+Scenario: Add two numbers
+	When I press
+		| foo |
+		| bar \

--- a/testdata/bad/backslash_at_end_of_line_in_datatable.feature.errors.ndjson
+++ b/testdata/bad/backslash_at_end_of_line_in_datatable.feature.errors.ndjson
@@ -1,0 +1,1 @@
+{"parseError":{"message":"(5:3): inconsistent cell count within the table","source":{"location":{"column":3,"line":5},"uri":"../testdata/bad/backslash_at_end_of_line_in_datatable.feature"}}}

--- a/testdata/bad/file_ends_with_open_docstring.feature
+++ b/testdata/bad/file_ends_with_open_docstring.feature
@@ -1,0 +1,4 @@
+Feature: Addition
+Scenario: Add two numbers
+  Given I have added
+    ```

--- a/testdata/bad/file_ends_with_open_docstring.feature.errors.ndjson
+++ b/testdata/bad/file_ends_with_open_docstring.feature.errors.ndjson
@@ -1,0 +1,1 @@
+{"parseError":{"message":"(5:0): unexpected end of file, expected: #DocStringSeparator, #Other","source":{"location":{"line":5},"uri":"../testdata/bad/file_ends_with_open_docstring.feature"}}}

--- a/testdata/bad/unexpected_end_of_file.feature
+++ b/testdata/bad/unexpected_end_of_file.feature
@@ -1,0 +1,2 @@
+Feature: Addition
+@tag

--- a/testdata/bad/unexpected_end_of_file.feature.errors.ndjson
+++ b/testdata/bad/unexpected_end_of_file.feature.errors.ndjson
@@ -1,0 +1,1 @@
+{"parseError":{"message":"(3:0): unexpected end of file, expected: #TagLine, #RuleLine, #Comment, #Empty","source":{"location":{"line":3},"uri":"../testdata/bad/unexpected_end_of_file.feature"}}}

--- a/testdata/bad/unfinished_datatable.feature
+++ b/testdata/bad/unfinished_datatable.feature
@@ -1,0 +1,5 @@
+Feature: Addition
+Scenario: Add two numbers
+	When I press
+		| foo |
+		| bar

--- a/testdata/bad/unfinished_datatable.feature.errors.ndjson
+++ b/testdata/bad/unfinished_datatable.feature.errors.ndjson
@@ -1,0 +1,1 @@
+{"parseError":{"message":"(5:3): inconsistent cell count within the table","source":{"location":{"column":3,"line":5},"uri":"../testdata/bad/unfinished_datatable.feature"}}}


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

- Added additional error handling edge cases as bad test data
- [c] Optimise error handling for empty datatable rows
- [Perl] Optimise error handling for unclosed DocStrings

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

These error handling edge cases were reported to the .NET implementation and fixed in an upstream project in 2019. Later, these fixes were also merged into the gherkin repository.
While working on some optimisations (see #344), the question arose whether the regression tests should be ported to the gherkin repository. This ensures that all implementations can handle these edge cases that have been reported by users.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

The Perl implementation in general (first time writing Perl 😉), and also whether the required check for EOF should be added to other cases in the Perl implementation (but maybe this is something for another PR).

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
