### PR TITLE
Exclude 'cpanfile' from Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,8 @@
   "extends": [
     "github>cucumber/renovate-config"
   ],
+  "cpanfile": {
+    "enabled": false
+  },
   "dependencyDashboard": true
 }


### PR DESCRIPTION
### 🤔 What's changed?

Renovate does not upgrade Perl dependencies anymore.

### ⚡️ What's your motivation? 

The Perl ecosystem is generally pretty good about managing its dependencies. Specifying minimum requirements is usually capability-based.

### 🏷️ What kind of change is this?

- :toolbox:

### ♻️ Anything particular you want feedback on?

How to upgrade the messages dependency on new messages releases? (It usually takes a few hours for new messages releases to become visible on MetaCPAN.)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
