### PR TITLE
[.NET] Reduce NuGet size by only targeting .NET Standard 2.0

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -20,8 +20,7 @@ on:
 
 jobs:
   test-dotnet:
-    # Failing on `ubuntu-24.04` (https://github.com/cucumber/gherkin/issues/349)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ## [Unreleased]
 
+### Changed
+- [.NET] Reduce NuGet size by only targeting .NET Standard 2.0
+
 ### Fixed
 - [.NET] Fix NuGet package generation
 

--- a/dotnet/Gherkin.Specs/Gherkin.Specs.csproj
+++ b/dotnet/Gherkin.Specs/Gherkin.Specs.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <StartupObject>Gherkin.Specs.CLI.Program</StartupObject>
   </PropertyGroup>

--- a/dotnet/Gherkin/Gherkin.csproj
+++ b/dotnet/Gherkin/Gherkin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>
     <Deterministic Condition="'$(Configuration)' == 'Release'">false</Deterministic>


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

- Reduce NuGet size by only targeting .NET Standard 2.0
- Only run windows specific test environments (.NET Framework 4.7.2) on windows
- Updated runner to ubuntu-latest

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

Fixes #349

The .NET tests run on different runtimes (.NET8, .NET9, .NET Framework 4.7.2).
In the github workflow (CI), Ubuntu is used to run the tests.
But Ubuntu/Linux doesn't have a Windows-only .NET Framework 4.7.2 installed.
Instead, Ubuntu used Mono to run the tests. However, as of Ubuntu 24.04, Mono is no longer installed. See https://github.com/actions/runner-images/issues/10636.
This means that even on Ubuntu-22.04 the Gherkin implementation is not tested on the real .NET Framework.
This PR changes that the .NET Framework 4.7.2 runtime is only tested on Windows machines.

On the other hand, we currently have the Gherkin implementation in two flavors (.NET 8 and .NET Standard 2.0).
Both flavors use identical code and the .NET 8 specific target framework can be dropped because .NET Standard 2.0 can also be used in .NET 8 and .NET 9.
This reduces the size of NuGet package and ensures that we test all binaries we ship with the tests we run in the github workflow (CI).

Microsoft also recommends targeting only .NET Standard 2.0 if no additional features or specific APIs are required. See [When to target netx.0 vs. netstandard](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-1-0#when-to-target-netx0-vs-netstandard) and [Cross-platform targeting](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting).

In Reqnroll, the target framework has also been reduced to .NET Standard 2.0 only.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

@Romfos I checked #67, but the linked Microsoft recommendation only applies to updating if you were already using one of the older frameworks (e.g. .NET 5). Am I missing something?

@gasparnagy Do you think this could be a problem in any way?

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
