### PR TITLE
ruby: Remove Windows from CI

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -30,8 +30,6 @@ jobs:
         include:
           - os: macos-latest
             ruby: '3.4'
-          - os: windows-latest
-            ruby: '3.4'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### 🤔 What's changed?

Remove Windows from CI from the ruby test matrix.

### ⚡️ What's your motivation? 

In https://github.com/cucumber/gherkin/pull/370 windows was added as an os to run tests on. However, these fail.

### 🏷️ What kind of change is this?
- :bug: Bug fix (non-breaking change which fixes a defect)

