### PR TITLE
Optimize GherkinDialect performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org).
 This document is formatted according to the principles of [Keep A CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- [Java] Optimize GherkinDialect performance ([#380](https://github.com/cucumber/gherkin/pull/380))
 
 ## [32.0.1] - 2025-03-27
 ### Fixed

--- a/java/src/main/java/io/cucumber/gherkin/GherkinDialect.java
+++ b/java/src/main/java/io/cucumber/gherkin/GherkinDialect.java
@@ -68,17 +68,17 @@ public final class GherkinDialect {
         this.andKeywords = requireNonNull(andKeywords);
         this.butKeywords = requireNonNull(butKeywords);
         
-        this.stepKeywords = uniqueKeywords(givenKeywords, whenKeywords, thenKeywords, andKeywords, butKeywords);
+        this.stepKeywords = distinctKeywords(givenKeywords, whenKeywords, thenKeywords, andKeywords, butKeywords);
         this.stepKeywordsTypes = aggregateKeywordTypes(givenKeywords, whenKeywords, thenKeywords, andKeywords, butKeywords);
     }
 
     @SafeVarargs
-    private static List<String> uniqueKeywords(List<String>... keywords) {
+    private static List<String> distinctKeywords(List<String>... keywords) {
         int totalSize = 0;
         for (List<String> keyword : keywords) {
             totalSize += keyword.size();
         }
-        LinkedHashSet<String> uniqueKeywords = new LinkedHashSet<>(totalSize);
+        Set<String> uniqueKeywords = new LinkedHashSet<>(totalSize);
         for (List<String> keyword : keywords) {
             uniqueKeywords.addAll(keyword);
         }
@@ -96,7 +96,7 @@ public final class GherkinDialect {
         addStepKeywordsTypes(stepKeywordsTypes, CONTEXT, givenKeywords);
         addStepKeywordsTypes(stepKeywordsTypes, ACTION, whenKeywords);
         addStepKeywordsTypes(stepKeywordsTypes, OUTCOME, thenKeywords);
-        addStepKeywordsTypes(stepKeywordsTypes, CONJUNCTION, uniqueKeywords(andKeywords, butKeywords));
+        addStepKeywordsTypes(stepKeywordsTypes, CONJUNCTION, distinctKeywords(andKeywords, butKeywords));
         stepKeywordsTypes.replaceAll((keyword, stepKeywordTypes) -> unmodifiableSet(stepKeywordTypes));
         return stepKeywordsTypes;
     }

--- a/java/src/main/java/io/cucumber/gherkin/GherkinDialect.java
+++ b/java/src/main/java/io/cucumber/gherkin/GherkinDialect.java
@@ -3,12 +3,20 @@ package io.cucumber.gherkin;
 import io.cucumber.messages.types.StepKeywordType;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
+import static io.cucumber.messages.types.StepKeywordType.ACTION;
+import static io.cucumber.messages.types.StepKeywordType.CONJUNCTION;
+import static io.cucumber.messages.types.StepKeywordType.CONTEXT;
+import static io.cucumber.messages.types.StepKeywordType.OUTCOME;
 import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
 
 public final class GherkinDialect {
@@ -27,9 +35,24 @@ public final class GherkinDialect {
     private final List<String> andKeywords;
     private final List<String> butKeywords;
     private final List<String> stepKeywords;
-    private final Map<String, List<StepKeywordType>> stepKeywordsTypes;
+    private final Map<String, Set<StepKeywordType>> stepKeywordsTypes;
 
-    GherkinDialect(String language, String name, String nativeName, List<String> featureKeywords, List<String> ruleKeywords, List<String> scenarioKeywords, List<String> scenarioOutlineKeywords, List<String> backgroundKeywords, List<String> examplesKeywords, List<String> givenKeywords, List<String> whenKeywords, List<String> thenKeywords, List<String> andKeywords, List<String> butKeywords) {
+    GherkinDialect(
+            String language,
+            String name,
+            String nativeName,
+            List<String> featureKeywords,
+            List<String> ruleKeywords,
+            List<String> scenarioKeywords,
+            List<String> scenarioOutlineKeywords,
+            List<String> backgroundKeywords,
+            List<String> examplesKeywords,
+            List<String> givenKeywords,
+            List<String> whenKeywords,
+            List<String> thenKeywords,
+            List<String> andKeywords,
+            List<String> butKeywords
+    ) {
         this.language = requireNonNull(language);
         this.name = requireNonNull(name);
         this.nativeName = requireNonNull(nativeName);
@@ -44,32 +67,48 @@ public final class GherkinDialect {
         this.thenKeywords = requireNonNull(thenKeywords);
         this.andKeywords = requireNonNull(andKeywords);
         this.butKeywords = requireNonNull(butKeywords);
-
-        List<String> stepKeywords = new ArrayList<>();
-        stepKeywords.addAll(givenKeywords);
-        stepKeywords.addAll(whenKeywords);
-        stepKeywords.addAll(thenKeywords);
-        stepKeywords.addAll(andKeywords);
-        stepKeywords.addAll(butKeywords);
-        this.stepKeywords = unmodifiableList(stepKeywords);
-
-        Map<String, List<StepKeywordType>> stepKeywordsTypes = new HashMap<>();
-        addStepKeywordsTypes(stepKeywordsTypes, getGivenKeywords(), StepKeywordType.CONTEXT);
-        addStepKeywordsTypes(stepKeywordsTypes, getWhenKeywords(), StepKeywordType.ACTION);
-        addStepKeywordsTypes(stepKeywordsTypes, getThenKeywords(), StepKeywordType.OUTCOME);
-
-        List<String> conjunctionKeywords = new ArrayList<>();
-        conjunctionKeywords.addAll(getAndKeywords());
-        conjunctionKeywords.addAll(getButKeywords());
-        addStepKeywordsTypes(stepKeywordsTypes, conjunctionKeywords, StepKeywordType.CONJUNCTION);
-        this.stepKeywordsTypes = stepKeywordsTypes;
+        
+        this.stepKeywords = uniqueKeywords(givenKeywords, whenKeywords, thenKeywords, andKeywords, butKeywords);
+        this.stepKeywordsTypes = aggregateKeywordTypes(givenKeywords, whenKeywords, thenKeywords, andKeywords, butKeywords);
     }
 
-    private static void addStepKeywordsTypes(Map<String, List<StepKeywordType>> h, List<String> keywords, StepKeywordType type) {
+    @SafeVarargs
+    private static List<String> uniqueKeywords(List<String>... keywords) {
+        int totalSize = 0;
+        for (List<String> keyword : keywords) {
+            totalSize += keyword.size();
+        }
+        LinkedHashSet<String> uniqueKeywords = new LinkedHashSet<>(totalSize);
+        for (List<String> keyword : keywords) {
+            uniqueKeywords.addAll(keyword);
+        }
+        return unmodifiableList(new ArrayList<>(uniqueKeywords));
+    }
+    
+    private static Map<String, Set<StepKeywordType>> aggregateKeywordTypes(
+            List<String> givenKeywords,
+            List<String> whenKeywords,
+            List<String> thenKeywords,
+            List<String> andKeywords,
+            List<String> butKeywords
+    ) {
+        Map<String, Set<StepKeywordType>> stepKeywordsTypes = new HashMap<>();
+        addStepKeywordsTypes(stepKeywordsTypes, CONTEXT, givenKeywords);
+        addStepKeywordsTypes(stepKeywordsTypes, ACTION, whenKeywords);
+        addStepKeywordsTypes(stepKeywordsTypes, OUTCOME, thenKeywords);
+        addStepKeywordsTypes(stepKeywordsTypes, CONJUNCTION, uniqueKeywords(andKeywords, butKeywords));
+        stepKeywordsTypes.replaceAll((keyword, stepKeywordTypes) -> unmodifiableSet(stepKeywordTypes));
+        return stepKeywordsTypes;
+    }
+
+    private static void addStepKeywordsTypes(Map<String, Set<StepKeywordType>> accumulator, StepKeywordType type, List<String> keywords) {
         for (String keyword : keywords) {
-            if (!h.containsKey(keyword))
-                h.put(keyword, new ArrayList<>());
-            h.get(keyword).add(type);
+            if (!accumulator.containsKey(keyword)) {
+                // Most keywords only have a single type.
+                accumulator.put(keyword, EnumSet.of(type));
+            } else {
+                accumulator.get(keyword).add(type);
+            }
         }
     }
 
@@ -101,8 +140,35 @@ public final class GherkinDialect {
         return stepKeywords;
     }
 
+    /**
+     * Returns the {@link StepKeywordType StepKeywordTypes} for a given keyword
+     * 
+     * @deprecated use {{@link #getStepKeywordTypesSet(String)}} instead.
+     * @param keyword to get the keyword type for
+     * @return the keywords type
+     */
+    @Deprecated
     public List<StepKeywordType> getStepKeywordTypes(String keyword) {
-        return stepKeywordsTypes.get(keyword);
+        Set<StepKeywordType> stepKeywordTypes = stepKeywordsTypes.get(keyword);
+        if (stepKeywordTypes == null) {
+            return null;
+        }
+        return new ArrayList<>(stepKeywordTypes);
+    }
+
+    /**
+     * Returns the {@link StepKeywordType StepKeywordTypes} for a given keyword
+     *
+     * @param keyword to get the keyword type for
+     * @return the keywords type
+     */
+    public Set<StepKeywordType> getStepKeywordTypesSet(String keyword) {
+        requireNonNull(keyword);
+        Set<StepKeywordType> stepKeywordTypes = stepKeywordsTypes.get(keyword);
+        if (stepKeywordTypes == null) {
+            throw new NoSuchElementException(String.format("'%s' is not part of this dialect", keyword));
+        }
+        return stepKeywordTypes;
     }
 
     public List<String> getBackgroundKeywords() {

--- a/java/src/main/java/io/cucumber/gherkin/GherkinDialectProvider.java
+++ b/java/src/main/java/io/cucumber/gherkin/GherkinDialectProvider.java
@@ -8,6 +8,7 @@ import static java.util.Objects.requireNonNull;
 public final class GherkinDialectProvider {
 
     private final String defaultDialectName;
+    private GherkinDialect defaultDialect;
 
     public GherkinDialectProvider(String defaultDialectName) {
         this.defaultDialectName = requireNonNull(defaultDialectName);
@@ -18,7 +19,11 @@ public final class GherkinDialectProvider {
     }
 
     public GherkinDialect getDefaultDialect() {
-        return getDialect(defaultDialectName).orElseThrow(() -> new ParserException.NoSuchLanguageException(defaultDialectName, null));
+        if (defaultDialect == null) {
+            this.defaultDialect = getDialect(defaultDialectName)
+                    .orElseThrow(() -> new ParserException.NoSuchLanguageException(defaultDialectName, null));
+        }
+        return defaultDialect;
     }
 
     public Optional<GherkinDialect> getDialect(String language) {

--- a/java/src/main/java/io/cucumber/gherkin/TokenMatcher.java
+++ b/java/src/main/java/io/cucumber/gherkin/TokenMatcher.java
@@ -1,10 +1,7 @@
 package io.cucumber.gherkin;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.AbstractMap.SimpleEntry;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -186,13 +183,20 @@ class TokenMatcher implements ITokenMatcher {
         for (String keyword : keywords) {
             if (token.line.startsWith(keyword)) {
                 String stepText = token.line.getRestTrimmed(keyword.length());
-                List<StepKeywordType> keywordTypes = currentDialect.getStepKeywordTypes(keyword);
-                StepKeywordType keywordType = (keywordTypes.size() > 1) ? StepKeywordType.UNKNOWN : keywordTypes.get(0);
+                StepKeywordType keywordType = getKeywordType(keyword);
                 setTokenMatched(token, TokenType.StepLine, stepText, keyword, null, keywordType, null);
                 return true;
             }
         }
         return false;
+    }
+
+    private StepKeywordType getKeywordType(String stepKeyword) {
+        Set<StepKeywordType> keywordTypes = currentDialect.getStepKeywordTypesSet(stepKeyword);
+        if (keywordTypes.size() == 1) {
+            return keywordTypes.iterator().next();
+        }
+        return StepKeywordType.UNKNOWN;
     }
 
     @Override

--- a/java/src/test/java/io/cucumber/gherkin/GherkinDialectProviderTest.java
+++ b/java/src/test/java/io/cucumber/gherkin/GherkinDialectProviderTest.java
@@ -4,15 +4,16 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
-import static io.cucumber.gherkin.StringUtils.symbolCount;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GherkinDialectProviderTest {
+    
     @Test
     public void provides_emoji_dialect() {
         GherkinDialect em = new GherkinDialectProvider().getDialect("em").orElseThrow(() -> new RuntimeException("Missing dialect: em"));
-        assertEquals(1, symbolCount(em.getScenarioKeywords().get(0)));
+        String actual = em.getScenarioKeywords().get(0);
+        assertEquals(1, actual.codePointCount(0, actual.length()));
     }
 
     @Test

--- a/java/src/test/java/io/cucumber/gherkin/GherkinDialectTest.java
+++ b/java/src/test/java/io/cucumber/gherkin/GherkinDialectTest.java
@@ -1,0 +1,53 @@
+package io.cucumber.gherkin;
+
+import io.cucumber.messages.types.StepKeywordType;
+import org.junit.jupiter.api.Test;
+
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GherkinDialectTest {
+
+    final GherkinDialect dialect = new GherkinDialectProvider().getDefaultDialect();
+    
+    @Test
+    void getDistinctStepKeywordTypes_star_has_multiple_stepKeywordTypes() {
+        // When I get the step keyword types
+        Set<StepKeywordType> stepKeywordTypes = dialect.getStepKeywordTypesSet("* ");
+
+        // Then multiple types are possible
+        assertEquals(4, stepKeywordTypes.size());
+    }
+    
+    @Test
+    void getDistinctStepKeywordTypes_Given_has_multiple_stepKeywordTypes() {
+        // When I get the step keyword types
+        Set<StepKeywordType> stepKeywordTypes = dialect.getStepKeywordTypesSet("Given ");
+
+        // Then multiple types are possible
+        assertEquals(1, stepKeywordTypes.size());
+    }
+    
+    @Test
+    void getDistinctStepKeywordTypes_null_throws() {
+        // When I get the step keyword types
+        assertThrows(NullPointerException.class, () -> dialect.getStepKeywordTypesSet(null));
+    }
+
+    @Test
+    void getDistinctStepKeywordTypes_unknown_throws() {
+        // When I get the step keyword types
+        assertThrows(NoSuchElementException.class, () -> dialect.getStepKeywordTypesSet("Unknown"));
+    }
+
+    @Test
+    void getName_returns_the_name_of_the_dialect() {
+        // When I get the name of the dialect
+        String name = dialect.getName();
+
+        // Then the name is "English"
+        assertEquals("English", name);
+    }
+}


### PR DESCRIPTION
### 🤔 What's changed?

Separating out the elements from https://github.com/cucumber/gherkin/pull/372 that involve the GherkinDialect

* Optimize memory size of `stepKeywords`
* Use `EnumSet` for `stepKeywordsTypes`
* Adds `getDistinctStepKeywordTypes` that returns the `EnumSet`
* Deprecates `getStepKeywordTypes`

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
