### PR TITLE
Added unit tests for Locations

### DIFF
--- a/java/src/main/java/io/cucumber/gherkin/Locations.java
+++ b/java/src/main/java/io/cucumber/gherkin/Locations.java
@@ -12,14 +12,14 @@ class Locations {
      * We can't use Long.valueOf() because it caches only the first 128
      * values, and typical feature files have much more lines.
      */
-    private final static Long[] longs = new Long[4000];
+    private static final Long[] longs = new Long[4096];
     static {
         for (int i = 0; i < longs.length; i++) {
             longs[i] = (long) i;
         }
     }
 
-    private static Long getLong(int i) {
+    static Long getLong(int i) {
         if (i>=longs.length) return (long) i;
         return longs[i];
     }

--- a/java/src/main/java/io/cucumber/gherkin/Locations.java
+++ b/java/src/main/java/io/cucumber/gherkin/Locations.java
@@ -20,6 +20,19 @@ class Locations {
     }
 
     static Long getLong(int i) {
+        // JMH benchmark shows that this implementation is the
+        // fastest when i<4096 (and about 20% slower than
+        // Long.valueOf() when i>=4096).
+        //
+        // Tested variants:
+        // - static preinitialized cache of 127 elements
+        //   (`Long.valueOf`)
+        // - static preinitialized cache of 4096 elements
+        //   (the current implemented version)
+        // - dynamic preinitialized cache with 256 / 512 /
+        //   1024/2048/4096 initial size
+        // - dynamic lazy initialized cache with 256
+        //   initialized size
         if (i>=longs.length) return (long) i;
         return longs[i];
     }

--- a/java/src/main/java/io/cucumber/gherkin/Locations.java
+++ b/java/src/main/java/io/cucumber/gherkin/Locations.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
 class Locations {
 
     /**
-     * Cache of Long objects for the range 0-3999. This is used
+     * Cache of Long objects for the range 0-4095. This is used
      * to avoid creating a huge amount of Long objects in getLocation().
      * We can't use Long.valueOf() because it caches only the first 128
      * values, and typical feature files have much more lines.
@@ -25,11 +25,11 @@ class Locations {
         // Long.valueOf() when i>=4096).
         //
         // Tested variants:
-        // - static preinitialized cache of 127 elements
+        // - static pre-initialized cache of 127 elements
         //   (`Long.valueOf`)
-        // - static preinitialized cache of 4096 elements
+        // - static pre-initialized cache of 4096 elements
         //   (the current implemented version)
-        // - dynamic preinitialized cache with 256 / 512 /
+        // - dynamic pre-initialized cache with 256 / 512 /
         //   1024/2048/4096 initial size
         // - dynamic lazy initialized cache with 256
         //   initialized size

--- a/java/src/main/java/io/cucumber/gherkin/Locations.java
+++ b/java/src/main/java/io/cucumber/gherkin/Locations.java
@@ -13,13 +13,14 @@ class Locations {
      * values, and typical feature files have much more lines.
      */
     private static final Long[] longs = new Long[4096];
+
     static {
         for (int i = 0; i < longs.length; i++) {
             longs[i] = (long) i;
         }
     }
 
-    static Long getLong(int i) {
+    private static Long getLong(int i) {
         // JMH benchmark shows that this implementation is the
         // fastest when i<4096 (and about 20% slower than
         // Long.valueOf() when i>=4096).
@@ -33,7 +34,9 @@ class Locations {
         //   1024/2048/4096 initial size
         // - dynamic lazy initialized cache with 256
         //   initialized size
-        if (i>=longs.length) return (long) i;
+        if (i >= longs.length) {
+            return (long) i;
+        }
         return longs[i];
     }
 
@@ -46,6 +49,9 @@ class Locations {
     }
 
     static Location atLine(int line) {
+        if (line < 0) {
+            throw new IllegalArgumentException("Lines are index-0 based");
+        }
         return new Location(getLong(line), null);
     }
 

--- a/java/src/test/java/io/cucumber/gherkin/LocationsTest.java
+++ b/java/src/test/java/io/cucumber/gherkin/LocationsTest.java
@@ -1,0 +1,57 @@
+package io.cucumber.gherkin;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LocationsTest {
+
+    @Test
+    void getLong() {
+        // random integer conversion that is far after the cache upper bound works
+        assertEquals(Long.valueOf(12000L), Locations.getLong(12000));
+
+        // sequential integer conversion works (the cache has no hole)
+        for (int i=0; i<12000; i++) {
+            Long expectedLong = (long)i;
+            assertEquals(expectedLong, Locations.getLong(i));
+        }
+    }
+
+    @Test
+    void getLong_negative_number_not_supported() {
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> Locations.getLong(-12000));
+    }
+
+    @Test
+    void getLong_multithread_does_not_raise_exception() {
+        // Given
+        AtomicInteger successCounter = new AtomicInteger(0);
+        int numberOfThreads = 1000;
+        int numberOfIterations = 20000;
+        Thread[] threads = new Thread[numberOfThreads];
+        for (int i = 0; i < numberOfThreads; i++) {
+            threads[i] = new Thread(() -> {
+                for (int j = 500; j < numberOfIterations; j *= 2) {
+                    Long expectedLong = (long)j;
+                    assertEquals(expectedLong, Locations.getLong(j));
+                }
+                successCounter.incrementAndGet();
+            });
+        }
+
+        // When
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        // Then
+        for (Thread thread : threads) {
+            assertDoesNotThrow(() -> thread.join());
+        }
+        assertEquals(numberOfThreads, successCounter.get());
+    }
+
+}

--- a/java/src/test/java/io/cucumber/gherkin/LocationsTest.java
+++ b/java/src/test/java/io/cucumber/gherkin/LocationsTest.java
@@ -1,5 +1,6 @@
 package io.cucumber.gherkin;
 
+import io.cucumber.messages.types.Location;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -9,24 +10,25 @@ import static org.junit.jupiter.api.Assertions.*;
 class LocationsTest {
 
     @Test
-    void getLong() {
+    void atLine() {
         // random integer conversion that is far after the cache upper bound works
-        assertEquals(Long.valueOf(12000L), Locations.getLong(12000));
-
+        Location location = Locations.atLine(12000);
+        assertEquals(Long.valueOf(12000L), location.getLine());
         // sequential integer conversion works (the cache has no hole)
-        for (int i=0; i<12000; i++) {
-            Long expectedLong = (long)i;
-            assertEquals(expectedLong, Locations.getLong(i));
+        for (int i = 0; i < 12000; i++) {
+            Long expectedLine = (long) i;
+            Location actual = Locations.atLine(i);
+            assertEquals(expectedLine, actual.getLine());
         }
     }
 
     @Test
-    void getLong_negative_number_not_supported() {
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> Locations.getLong(-12000));
+    void atLine_negative_number_not_supported() {
+        assertThrows(IllegalArgumentException.class, () -> Locations.atLine(-1));
     }
 
     @Test
-    void getLong_multithread_does_not_raise_exception() {
+    void atLine_multithreaded_does_not_raise_exception() {
         // Given
         AtomicInteger successCounter = new AtomicInteger(0);
         int numberOfThreads = 1000;
@@ -35,8 +37,9 @@ class LocationsTest {
         for (int i = 0; i < numberOfThreads; i++) {
             threads[i] = new Thread(() -> {
                 for (int j = 500; j < numberOfIterations; j *= 2) {
-                    Long expectedLong = (long)j;
-                    assertEquals(expectedLong, Locations.getLong(j));
+                    Long expectedLine = (long) j;
+                    Location actual = Locations.atLine(j);
+                    assertEquals(expectedLine, actual.getLine());
                 }
                 successCounter.incrementAndGet();
             });


### PR DESCRIPTION
### 🤔 What's changed?

Added unit tests for `Locations`.

### ⚡️ What's your motivation? 

Ensure that the new `Locations.getLong()` method works properly (behavior, thread-safety and performance).

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

TLDR: the current version is the fastest one.

I made a micro-benchmark for different variants and it appears that this one is the fastest for feature files up to 4000 lines. When the feature file contains more than 4000 lines, performance is a bit slower than the original `Long.valueOf`. But this is a very long feature file and probably against the good BDD practices. According to ChatGPT, the typical feature file is up to 50 lines and max 300 lines (I didn't verify).

I tested several variants:
- static preinitialized cache of 127 elements (`Long.valueOf`)
- static preinitialized cache of 4096 elements (the current implemented version)
- dynamic preinitialized cache with 256/512/1024/2048/4096 initial size
- dynamic lazy initialized cache with 256 initialized size

When using dynamic cache size, we need to ensure thread-safety (two threads may increase the cache size at the same time).

The dynamic preinitialized cache looks like this (working on local references ensures thread-safety):

```
    private static Long[] longs3 = new Long[256];
    static {
        for (int i = 0; i < longs3.length; i++) {
            longs3[i] = (long) i;
        }
    }

    public static Long getLongDynCachePreset256(int i) {
        // race condition is possible when several threads try
        // to increase the cache size in parallel, but it's not
        // a problem in this case. We'll only compute the same
        // cache twice when the cache size increases (but the
        // probability is very low). Thus, there is no need to
        // synchronize the cache. We only need to ensure that no
        // NPE occurs by working on a local reference (localLongs)
        // that is not shared with the other threads.
        Long[] localLongs = longs3;
        int cacheLength = localLongs.length;
        if (i >= cacheLength) {
            localLongs = Arrays.copyOf(localLongs, Math.max(cacheLength * 2, i + 1));
            for (int j = cacheLength; j < localLongs.length; j++) {
                localLongs[j] = (long) j; // create a new Long
            }
            longs3 = localLongs;
        }
        return localLongs[i];
    }
```

Using `synchronized` blocks to ensure thread-safety is not working: when the number of threads is about 15-20, it's becoming very slow and `OutOfMemoryError` occurs.

The dynamic lazy initialized cache looks like this:

```
    private static Long[] longs4 = new Long[256];

    public static Long getLongDynCacheOnDemand256(int i) {
        Long[] localLongs = longs4;
        int length = localLongs.length;
        if (i >= length) {
            localLongs = Arrays.copyOf(localLongs, Math.max(length * 2, i + 1));
            longs4 = localLongs;

            // we need to compute the first value at the same time
            // we increase the cache size to guarantee thread-safety.
            Long longValue = (long)i;
            localLongs[i]= longValue; // create a new Long
            return longValue;
        }
        Long longValue = localLongs[i];
        if (longValue == null) {
            longValue = (long) i; // create a new Long
            longs4[i] = longValue;
        }
        return longValue;
    }
```

The JMH benchmark shows that the current version is the fastest one on files that have less than 4096 lines (improvement to up to 90% over the default `Long.valueOf` and 6-13% faster than the dynamic lazy initialized cache):

![image](https://github.com/user-attachments/assets/523a28c8-cb5a-43e6-af4b-e51c410cd5c4)

For feature files longer than 4096 lines, we could eventually combine implementations (`if (i >= longs.length) return getLongDynCacheOnDemand256(i)`) but this would be rarely used and would make the code more complex, so I don't think this is a good idea.


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
