### PR TITLE
java: Prefer the longest step keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 - [cpp] Actually use the VERSION file ([#376](https://github.com/cucumber/gherkin/pull/376))
+- [Java] Prefer the longest step keyword ([#401](https://github.com/cucumber/gherkin/pull/401))
 
 ## [32.1.1] - 2025-04-11
 ### Fixed

--- a/java/src/main/java/io/cucumber/gherkin/GherkinDialect.java
+++ b/java/src/main/java/io/cucumber/gherkin/GherkinDialect.java
@@ -3,6 +3,8 @@ package io.cucumber.gherkin;
 import io.cucumber.messages.types.StepKeywordType;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -82,7 +84,11 @@ public final class GherkinDialect {
         for (List<String> keyword : keywords) {
             uniqueKeywords.addAll(keyword);
         }
-        return unmodifiableList(new ArrayList<>(uniqueKeywords));
+        List<String> sortedKeywords = new ArrayList<>(uniqueKeywords);
+        // Sort from longest to shortest
+        Comparator<String> naturalOrder = Comparator.naturalOrder();
+        Collections.sort(sortedKeywords, naturalOrder.reversed());
+        return unmodifiableList(sortedKeywords);
     }
     
     private static Map<String, Set<StepKeywordType>> aggregateKeywordTypes(


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Step keywords may be prefixes of each other. For example in French several variations of given start with `Etant donné`. When this is the case Gherkin should prefer the longest possible keyword.

This is currently only implicitly enforced by manually ordering the keywords.

However, for Creole language the prefixes are spread between then and when so manually sorting them is no longer possible.

Partially resolves: #400

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes in https://github.com/cucumber/gherkin/pull/402.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
