### PR TITLE
[PHP] Prefer the longest step keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ### Fixed
 - [cpp] Actually use the VERSION file ([#376](https://github.com/cucumber/gherkin/pull/376))
 - [Java] Prefer the longest step keyword ([#401](https://github.com/cucumber/gherkin/pull/401))
+- [PHP] Prefer the longest step keyword ([#403](https://github.com/cucumber/gherkin/pull/403))
 
 ## [32.1.1] - 2025-04-11
 ### Fixed

--- a/php/.gitignore
+++ b/php/.gitignore
@@ -8,3 +8,4 @@ composer.lock
 .deps
 .compared
 .tested
+.built

--- a/php/src/GherkinDialect.php
+++ b/php/src/GherkinDialect.php
@@ -21,6 +21,9 @@ namespace Cucumber\Gherkin;
  */
 final class GherkinDialect
 {
+    /** @var non-empty-list<non-empty-string> */
+    private readonly array $stepKeywords;
+
     /**
      * @param Dialect $dialect
      */
@@ -28,6 +31,7 @@ final class GherkinDialect
         private readonly string $language,
         private readonly array $dialect,
     ) {
+        $this->stepKeywords = $this->buildStepKeywords();
     }
 
     public function getLanguage(): string
@@ -98,18 +102,29 @@ final class GherkinDialect
     /** @return non-empty-list<non-empty-string> */
     public function getStepKeywords(): array
     {
-        return [
-            ...$this->getGivenKeywords(),
-            ...$this->getWhenKeywords(),
-            ...$this->getThenKeywords(),
-            ...$this->getAndKeywords(),
-            ...$this->getButKeywords(),
-        ];
+        return $this->stepKeywords;
     }
 
     /** @return non-empty-list<non-empty-string> */
     public function getExamplesKeywords(): array
     {
         return $this->dialect['examples'];
+    }
+
+    /** @return non-empty-list<non-empty-string> */
+    private function buildStepKeywords(): array
+    {
+        $keywords = [
+            ...$this->getGivenKeywords(),
+            ...$this->getWhenKeywords(),
+            ...$this->getThenKeywords(),
+            ...$this->getAndKeywords(),
+            ...$this->getButKeywords(),
+        ];
+
+        // Sort longer keywords before shorter keywords being their prefix
+        rsort($keywords);
+
+        return $keywords;
     }
 }

--- a/php/tests/GherkinDialectTest.php
+++ b/php/tests/GherkinDialectTest.php
@@ -92,11 +92,11 @@ final class GherkinDialectTest extends TestCase
     public function testItReturnsTheMergedStepKeywords(): void
     {
         $expected = [
-            'G1', 'G2', 'G3',
-            'W1', 'W2', 'W3',
-            'T1', 'T2', 'T3',
-            'A1', 'A2', 'A3',
-            'B1', 'B2', 'B3',
+            'W3', 'W2', 'W1',
+            'T3', 'T2', 'T1',
+            'G3', 'G2', 'G1',
+            'B3', 'B2', 'B1',
+            'A3', 'A2', 'A1',
         ];
         self::assertSame($expected, $this->dialect->getStepKeywords());
     }


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Step keywords may be prefixes of each other. For example in French several variations of given start with `Etant donné`. When this is the case Gherkin should prefer the longest possible keyword.

This is currently only implicitly enforced by manually ordering the keywords.

However, for Creole language the prefixes are spread between then and when so manually sorting them is no longer possible.

This is the PHP implementation of the fix for #400.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes. See #402
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.