### PR TITLE
[c] Fix setting keyword type when matching Action or Outcome

### DIFF
--- a/c/src/token_matcher.c
+++ b/c/src/token_matcher.c
@@ -137,14 +137,14 @@ bool TokenMatcher_match_StepLine(TokenMatcher* token_matcher, Token* token) {
     keywords_result = match_step_keywords(token, Keyword_Action, token_matcher->dialect->when_keywords);
     if (keywords_result) {
         if (final_result) {
-	    token->matched_keyword_type = Keyword_Unknown;
+	    token->matched_keyword_type = Keyword_Action;
 	}
         final_result = true;
     }
     keywords_result = match_step_keywords(token, Keyword_Outcome, token_matcher->dialect->then_keywords);
     if (keywords_result) {
         if (final_result) {
-	    token->matched_keyword_type = Keyword_Unknown;
+	    token->matched_keyword_type = Keyword_Outcome;
 	}
         final_result = true;
     }


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->
Sets the matched keyword type to `Keyword_Action` or `Keyword_Outcome`, rather than to `Keyword_Unknown`, when matching keywords of the respective types.

### ⚡️ What's your motivation? 

When this PR is combined with https://github.com/cucumber/gherkin/pull/417, the C acceptance tests (`make acceptance`) pass. Together, these two PR’s constitute a partial fix for https://github.com/cucumber/gherkin/issues/412.
<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->
I was surprised I did not have to change `Keyword_Unknown` to `Keyword_Conjunction` for the and/but case, which seems to parallel the action and outcome cases. If I do change the and/but case, the acceptance tests fail.

https://github.com/cucumber/gherkin/blob/768a54048dce8edb87205ff719f313622551c800/c/src/token_matcher.c#L151-L158

I would love to understand why I *didn’t* need to change this case. 

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes. **N/A, fixes existing tests**
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
