### PR TITLE
go: update to latest version of messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 - [cpp] Add missing translations for Rule ([#415](https://github.com/cucumber/gherkin/pull/415))
 - [cpp] Prefer the longest step keyword ([#416](https://github.com/cucumber/gherkin/pull/416))
 - [Python] Fix acceptance tests ([#64](https://github.com/cucumber/gherkin/pull/64))
-- [go] Use latest version of messages ([#420](https://github.com/cucumber/gherkin/pull/420))
+
+### Changed
+- [go] Use messages v28 ([#420](https://github.com/cucumber/gherkin/pull/420))
 
 ## [32.1.2] - 2025-05-25
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ var pickles = Gherkin.compile(
 #### Go
 
 ```go
-// Download the package via: `go get github.com/cucumber/gherkin/go/v27`
-//   && go get "github.com/cucumber/messages/go/v27"
+// Download the package via: `go get github.com/cucumber/gherkin/go/v28`
+//   && go get "github.com/cucumber/messages/go/v28"
 import (
   "strings"
 
-  gherkin "github.com/cucumber/gherkin/go/v27"
-  messages "github.com/cucumber/messages/go/v27"
+  gherkin "github.com/cucumber/gherkin/go/v28"
+  messages "github.com/cucumber/messages/go/v28"
 )
 
 func main() {

--- a/go/astbuilder.go
+++ b/go/astbuilder.go
@@ -1,7 +1,7 @@
 package gherkin
 
 import (
-	"github.com/cucumber/messages/go/v27"
+	"github.com/cucumber/messages/go/v28"
 	"strings"
 )
 

--- a/go/bench_test.go
+++ b/go/bench_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	messages "github.com/cucumber/messages/go/v27"
+	messages "github.com/cucumber/messages/go/v28"
 )
 
 const benchmarkGherkinText = `

--- a/go/dialect.go
+++ b/go/dialect.go
@@ -3,7 +3,7 @@ package gherkin
 import (
 	"sort"
 
-	messages "github.com/cucumber/messages/go/v27"
+	messages "github.com/cucumber/messages/go/v28"
 )
 
 func init() {

--- a/go/dialects_builtin.go
+++ b/go/dialects_builtin.go
@@ -2,7 +2,7 @@
 
 package gherkin
 
-import messages "github.com/cucumber/messages/go/v27"
+import messages "github.com/cucumber/messages/go/v28"
 
 // Builtin dialects for af (Afrikaans), am (Armenian), an (Aragonese), ar (Arabic), ast (Asturian), az (Azerbaijani), be (Belarusian), bg (Bulgarian), bm (Malay), bs (Bosnian), ca (Catalan), cs (Czech), cy-GB (Welsh), da (Danish), de (German), el (Greek), em (Emoji), en (English), en-Scouse (Scouse), en-au (Australian), en-lol (LOLCAT), en-old (Old English), en-pirate (Pirate), en-tx (Texas), eo (Esperanto), es (Spanish), et (Estonian), fa (Persian), fi (Finnish), fr (French), ga (Irish), gj (Gujarati), gl (Galician), he (Hebrew), hi (Hindi), hr (Croatian), ht (Creole), hu (Hungarian), id (Indonesian), is (Icelandic), it (Italian), ja (Japanese), jv (Javanese), ka (Georgian), kn (Kannada), ko (Korean), lt (Lithuanian), lu (Luxemburgish), lv (Latvian), mk-Cyrl (Macedonian), mk-Latn (Macedonian (Latin)), mn (Mongolian), ne (Nepali), nl (Dutch), no (Norwegian), pa (Panjabi), pl (Polish), pt (Portuguese), ro (Romanian), ru (Russian), sk (Slovak), sl (Slovenian), sr-Cyrl (Serbian), sr-Latn (Serbian (Latin)), sv (Swedish), ta (Tamil), th (Thai), te (Telugu), tlh (Klingon), tr (Turkish), tt (Tatar), uk (Ukrainian), ur (Urdu), uz (Uzbek), vi (Vietnamese), zh-CN (Chinese simplified), ml (Malayalam), zh-TW (Chinese traditional), mr (Marathi), amh (Amharic)
 func DialectsBuiltin() DialectProvider {

--- a/go/dialects_builtin.go.jq
+++ b/go/dialects_builtin.go.jq
@@ -91,7 +91,7 @@
   )
 | "// Code generated from dialects_builtin.go.jq (make dialects_builtin.go); DO NOT EDIT.\n\n" # Standard header defined at https://golang.org/s/generatedcode
 + "package gherkin\n\n"
-+ "import messages \"github.com/cucumber/messages/go/v27\"\n\n"
++ "import messages \"github.com/cucumber/messages/go/v28\"\n\n"
 + "// Builtin dialects for " + ([ $root | to_entries[] | .key+" ("+.value.name+")" ] | join(", ")) + "\n"
 + "func DialectsBuiltin() DialectProvider {\n"
 + "\treturn builtinDialects\n"

--- a/go/example_test.go
+++ b/go/example_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	messages "github.com/cucumber/messages/go/v27"
+	messages "github.com/cucumber/messages/go/v28"
 )
 
 func ExampleParseGherkinDocument() {

--- a/go/gherkin.go
+++ b/go/gherkin.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	messages "github.com/cucumber/messages/go/v27"
+	messages "github.com/cucumber/messages/go/v28"
 )
 
 type Parser interface {

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,7 +1,7 @@
 module github.com/cucumber/gherkin/go/v32
 
 require (
-	github.com/cucumber/messages/go/v27 v27.2.0
+	github.com/cucumber/messages/go/v28 v28.0.0
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,5 +1,5 @@
-github.com/cucumber/messages/go/v27 v27.2.0 h1:OEua29JSq9p5k7v+GTunlFt/SxJR5UsdFVn7Qh47QLU=
-github.com/cucumber/messages/go/v27 v27.2.0/go.mod h1:SosDXTT3f+YEYRdjS1bBGmcG6AJkQgJEmhzaBhd0AQw=
+github.com/cucumber/messages/go/v28 v28.0.0 h1:BOJmy8LKSbdKxM6Ba1v9ZmpZk7j5cyH+LTAaGxMeflc=
+github.com/cucumber/messages/go/v28 v28.0.0/go.mod h1:2njGQBk+mu0aqzQgN8xcXvnrfWNcP7UjEyi1YauQ5Lc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/go/main/main.go
+++ b/go/main/main.go
@@ -12,7 +12,7 @@ import (
 	"os"
 
 	gherkin "github.com/cucumber/gherkin/go/v32"
-	"github.com/cucumber/messages/go/v27"
+	"github.com/cucumber/messages/go/v28"
 )
 
 var noSource = flag.Bool("no-source", false, "Skip gherkin source events")

--- a/go/messages.go
+++ b/go/messages.go
@@ -3,7 +3,7 @@ package gherkin
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/cucumber/messages/go/v27"
+	"github.com/cucumber/messages/go/v28"
 	"io"
 	"io/ioutil"
 	"strings"

--- a/go/messages_test.go
+++ b/go/messages_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	messages "github.com/cucumber/messages/go/v27"
+	messages "github.com/cucumber/messages/go/v28"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go/pickles.go
+++ b/go/pickles.go
@@ -1,7 +1,7 @@
 package gherkin
 
 import (
-	"github.com/cucumber/messages/go/v27"
+	"github.com/cucumber/messages/go/v28"
 	"strings"
 )
 

--- a/go/pickles_test.go
+++ b/go/pickles_test.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strings"
 
-	messages "github.com/cucumber/messages/go/v27"
+	messages "github.com/cucumber/messages/go/v28"
 )
 
-func ExampleCompilePickles() {
+func ExamplePickles() {
 
 	input := `Feature: test
 


### PR DESCRIPTION
### 🤔 What's changed?

Update github.com/cucumber/messages/go/v24 to github.com/cucumber/messages/go/v28

### ⚡️ What's your motivation? 

Our renovate bot keeps pushing this update and we are stuck because new version of the gherkin lib still use the old messages version

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
