### PR TITLE
java: Use a more consistent definition of whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ## [Unreleased]
 ### Fixed
-[Go] Trim trailing tab characters from title and step lines ([#441](https://github.com/cucumber/gherkin/pull/441))
+- [Go] Trim trailing tab characters from title and step lines ([#441](https://github.com/cucumber/gherkin/pull/441))
+- [Java] Use a more consistent definition of whitespace ([#442](https://github.com/cucumber/gherkin/pull/442))
 
 ## [33.0.0] - 2025-07-07
 ### Changed

--- a/java/src/test/java/io/cucumber/gherkin/GherkinLineTest.java
+++ b/java/src/test/java/io/cucumber/gherkin/GherkinLineTest.java
@@ -93,6 +93,16 @@ class GherkinLineTest {
                 new GherkinLineSpan(7, "@is")
         ), gherkinLineSpans);
     }
+    @Test
+    void finds_tags__comment_inside_tag_preceded_by_nbsp() {
+        GherkinLine gherkinLine = new GherkinLine("@this @is\u202F#acomment  ", line);
+        List<GherkinLineSpan> gherkinLineSpans = gherkinLine.parseTags();
+
+        assertEquals(asList(
+                new GherkinLineSpan(1, "@this"),
+                new GherkinLineSpan(7, "@is")
+        ), gherkinLineSpans);
+    }
 
     @Test
     void finds_tags__commented_before_tag() {

--- a/java/src/test/java/io/cucumber/gherkin/StringUtilsTest.java
+++ b/java/src/test/java/io/cucumber/gherkin/StringUtilsTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map.Entry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StringUtilsTest {
     private static final String WHITESPACE = "\u00A0 \t";
@@ -62,6 +63,41 @@ class StringUtilsTest {
         assertEquals("@this @is @a @sequence of tags", StringUtils.removeComments("@this @is @a @sequence of tags #with a comment"));
         assertEquals("@this @is @a @sequence of tags", StringUtils.removeComments("@this @is @a @sequence of tags"));
         assertEquals("@issue#1234 @issue#31415", StringUtils.removeComments("@issue#1234 @issue#31415"));
+    }
+
+    @Test
+    void isWhiteSpace() {
+        char[] whitespace = new char[]{
+                '\t',
+                '\n',
+                '\u000B',
+                '\f',
+                '\r',
+                ' ',
+                '\u0085',
+                '\u00A0',
+                '\u1680',
+                '\u2000',
+                '\u2001',
+                '\u2002',
+                '\u2003',
+                '\u2004',
+                '\u2005',
+                '\u2006',
+                '\u2007',
+                '\u2008',
+                '\u2009',
+                '\u200A',
+                '\u2028',
+                '\u2029',
+                '\u202F',
+                '\u205F',
+                '\u3000'
+        };
+
+        for (char c : whitespace) {
+            assertTrue(StringUtils.isWhiteSpace(c), Character.getName(c) + " was not whitespace");
+        }
     }
 
 }

--- a/java/src/test/java/io/cucumber/gherkin/StringUtilsTest.java
+++ b/java/src/test/java/io/cucumber/gherkin/StringUtilsTest.java
@@ -67,6 +67,7 @@ class StringUtilsTest {
 
     @Test
     void isWhiteSpace() {
+        // https://en.wikipedia.org/wiki/Whitespace_character#Unicode
         char[] whitespace = new char[]{
                 '\t',
                 '\n',


### PR DESCRIPTION
### 🤔 What's changed?

Define whitespace as Unicode category `Zs` or its bidirectional class `WS`, `B`, or `S`.

### ⚡️ What's your motivation? 

Gherkin lines were trimmed according regex pattern `\s` + NEL + NBSP while comments on tags lines were assumed to be delimited by just `\s#`. This leads to some inconsistent behaviour where adding a comment to the end of a tag line can make the tag line invalid.

Each Gherkin implementations uses different definitions of whitespace.

These can be roughly categorized as using Unicode:

* C uses a hardcoded set from Wikipedia Whitespace character Unicode table[1]
* .Net uses Unicode category `Zs`, `Zl` and `Zp` and `\t`, `\v`, `\f`, `\r` and NEL[3].
* Javascript uses the regex pattern `\s` which match the set used by C + BOM[4]
* Python uses Unicode category `Zs` or its bidirectional class `WS`, `B`, or `S`[5].

And the other category:
* CPP uses the default locale ` `, `\f`, `\n`, `\r`, `\t` and `\v`[2].
* Ruby uses the same as CPP + null[6]
* Go only includes ` ` and `\t`.

Within the Unicode categorization there is significant overlap. So for Java I have chosen to match the Python definition of whitespace as it is completely defined in Unicode terms.

 1. https://en.wikipedia.org/wiki/Whitespace_character#Unicode
 2. https://en.cppreference.com/w/cpp/string/byte/isspace.html
 3. https://learn.microsoft.com/en-us/dotnet/api/system.char.iswhitespace?view=net-9.0
 4. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes
 5. https://docs.python.org/3/library/stdtypes.html#str.isspace
 6. https://ruby-doc.org/3.4.1/String.html#class-String-label-Whitespace+in+Strings

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
