### PR TITLE
StepLine identification loop unrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org).
 This document is formatted according to the principles of [Keep A CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Changed
+- [Java] Optimize GherkinTokenMatcher performance ([#443](https://github.com/cucumber/gherkin/pull/443))
 
 ## [33.1.0] - 2025-07-27
 ### Changed

--- a/java/src/main/java/io/cucumber/gherkin/GherkinLine.java
+++ b/java/src/main/java/io/cucumber/gherkin/GherkinLine.java
@@ -73,4 +73,7 @@ class GherkinLine {
                text.startsWith(keyword);
     }
 
+    public int getTextLength() {
+        return textLength;
+    }
 }

--- a/java/src/main/java/io/cucumber/gherkin/GherkinTokenMatcher.java
+++ b/java/src/main/java/io/cucumber/gherkin/GherkinTokenMatcher.java
@@ -230,28 +230,27 @@ class GherkinTokenMatcher implements TokenMatcher {
     @Override
     public boolean match_StepLine(Token token) {
         GherkinLine line = token.line;
-        String text = line.getText();
-        if (stepLineElem0.keywordIsAtStartOfLine(text)) {
+        if (stepLineElem0.keywordIsAtStartOfLine(line)) {
             matchStepKeyword(token, stepLineElem0);
             return true;
         }
-        if (stepLineElem1.keywordIsAtStartOfLine(text)) {
+        if (stepLineElem1.keywordIsAtStartOfLine(line)) {
             matchStepKeyword(token, stepLineElem1);
             return true;
         }
-        if (stepLineElem2.keywordIsAtStartOfLine(text)) {
+        if (stepLineElem2.keywordIsAtStartOfLine(line)) {
             matchStepKeyword(token, stepLineElem2);
             return true;
         }
-        if (stepLineElem3.keywordIsAtStartOfLine(text)) {
+        if (stepLineElem3.keywordIsAtStartOfLine(line)) {
             matchStepKeyword(token, stepLineElem3);
             return true;
         }
-        if (stepLineElem4.keywordIsAtStartOfLine(text)) {
+        if (stepLineElem4.keywordIsAtStartOfLine(line)) {
             matchStepKeyword(token, stepLineElem4);
             return true;
         }
-        if (stepLineElem5.keywordIsAtStartOfLine(text)) {
+        if (stepLineElem5.keywordIsAtStartOfLine(line)) {
             matchStepKeyword(token, stepLineElem5);
             return true;
         }
@@ -316,12 +315,13 @@ class GherkinTokenMatcher implements TokenMatcher {
             this.keywordChars = keyword.toCharArray();
         }
 
-        public boolean keywordIsAtStartOfLine(String textChars) {
-            if (textChars.length() < keywordLength) {
+        public boolean keywordIsAtStartOfLine(GherkinLine textChars) {
+            if (textChars.getTextLength() < keywordLength) {
                 return false;
             }
+            String text = textChars.getText();
             for (int i = 0; i < keywordLength; i++) {
-                if (textChars.charAt(i) != keywordChars[i]) {
+                if (text.charAt(i) != keywordChars[i]) {
                     return false;
                 }
             }

--- a/java/src/main/java/io/cucumber/gherkin/GherkinTokenMatcher.java
+++ b/java/src/main/java/io/cucumber/gherkin/GherkinTokenMatcher.java
@@ -199,7 +199,7 @@ class GherkinTokenMatcher implements TokenMatcher {
 
     private void prepareStepLineLoopUnrolling() {
         // Loop unrolling the step line keyword matching
-        // is ~2x faster than using a loop.
+        // is ~30% faster than using a loop.
         // There are at least 6 keywords (Given, When, Then,
         // And, But, *) in the English dialect, but some dialects
         // may have more keywords. Thus, we unroll the first 6

--- a/java/src/main/java/io/cucumber/gherkin/GherkinTokenMatcher.java
+++ b/java/src/main/java/io/cucumber/gherkin/GherkinTokenMatcher.java
@@ -26,11 +26,11 @@ class GherkinTokenMatcher implements TokenMatcher {
     private GherkinDialect currentDialect;
     private String activeDocStringSeparator = null;
     private int indentToRemove = 0;
+    private StepLineElem stepLineElem0;
     private StepLineElem stepLineElem1;
     private StepLineElem stepLineElem2;
     private StepLineElem stepLineElem3;
     private StepLineElem stepLineElem4;
-    private StepLineElem stepLineElem0;
     private StepLineElem stepLineElem5;
     private List<StepLineElem> remainingStepLineElems;
 
@@ -49,7 +49,10 @@ class GherkinTokenMatcher implements TokenMatcher {
 
     @Override
     public void reset() {
-        // TODO performance: reset() is called once in the constructor and once for each file (Parser.parse()). It could be called only once, but there is no measurable impact with the profiler
+        // reset() is called once in the constructor and
+        // once for each file (Parser.parse()). It could
+        // be called only once, but there is no measurable
+        // impact with the profiler
         activeDocStringSeparator = null;
         indentToRemove = 0;
         currentDialect = dialectProvider.getDefaultDialect();
@@ -196,7 +199,7 @@ class GherkinTokenMatcher implements TokenMatcher {
 
     private void prepareStepLineLoopUnrolling() {
         // Loop unrolling the step line keyword matching
-        // is 2x faster than using a loop.
+        // is ~2x faster than using a loop.
         // There are at least 6 keywords (Given, When, Then,
         // And, But, *) in the English dialect, but some dialects
         // may have more keywords. Thus, we unroll the first 6
@@ -220,34 +223,36 @@ class GherkinTokenMatcher implements TokenMatcher {
 
     }
 
+    @SuppressWarnings("Duplicates") // unrolling leads to duplicated code
     @Override
     public boolean match_StepLine(Token token) {
-        if (token.line.startsWith(stepLineElem0.keyword)) {
+        GherkinLine line = token.line;
+        if (line.startsWith(stepLineElem0.keyword)) {
             matchStepKeyword(token, stepLineElem0);
             return true;
         }
-        if (token.line.startsWith(stepLineElem1.keyword)) {
+        if (line.startsWith(stepLineElem1.keyword)) {
             matchStepKeyword(token, stepLineElem1);
             return true;
         }
-        if (token.line.startsWith(stepLineElem2.keyword)) {
+        if (line.startsWith(stepLineElem2.keyword)) {
             matchStepKeyword(token, stepLineElem2);
             return true;
         }
-        if (token.line.startsWith(stepLineElem3.keyword)) {
+        if (line.startsWith(stepLineElem3.keyword)) {
             matchStepKeyword(token, stepLineElem3);
             return true;
         }
-        if (token.line.startsWith(stepLineElem4.keyword)) {
+        if (line.startsWith(stepLineElem4.keyword)) {
             matchStepKeyword(token, stepLineElem4);
             return true;
         }
-        if (token.line.startsWith(stepLineElem5.keyword)) {
+        if (line.startsWith(stepLineElem5.keyword)) {
             matchStepKeyword(token, stepLineElem5);
             return true;
         }
         for (StepLineElem stepLineElem : remainingStepLineElems) {
-            if (token.line.startsWith(stepLineElem.keyword)) {
+            if (line.startsWith(stepLineElem.keyword)) {
                 matchStepKeyword(token, stepLineElem);
                 return true;
             }

--- a/java/src/test/java/io/cucumber/gherkin/GherkinTokenMatcherTest.java
+++ b/java/src/test/java/io/cucumber/gherkin/GherkinTokenMatcherTest.java
@@ -26,4 +26,18 @@ class GherkinTokenMatcherTest {
         // Then
         assertTrue(isStepLine, "Expected step line to match with language 'ht'");
     }
+
+    @Test
+    void reset_after_match_Language_change_the_language() {
+        // Given
+        GherkinTokenMatcher matcher = new GherkinTokenMatcher("en");
+        matcher.match_Language(Token.createGherkinLine("# language: ht", Locations.atLine(1)));
+        matcher.reset();
+
+        // When
+        boolean isStepLine = matcher.match_StepLine(Token.createGherkinLine("    Given there should be agent J", Locations.atLine(2)));
+
+        // Then
+        assertTrue(isStepLine, "Expected step line to match with language 'en'");
+    }
 }

--- a/java/src/test/java/io/cucumber/gherkin/GherkinTokenMatcherTest.java
+++ b/java/src/test/java/io/cucumber/gherkin/GherkinTokenMatcherTest.java
@@ -7,6 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class GherkinTokenMatcherTest {
 
     @Test
+    void each_language_must_have_at_least_6_keywords_for_unrolling() {
+        GherkinDialects.DIALECTS.forEach((language, dialect) -> {
+            assertTrue(dialect.getStepKeywords().size() >= 6,
+                    "Language '" + language + "' must have at least 6 keywords for unrolling, but has " + dialect.getStepKeywords().size());
+        });
+    }
+
+    @Test
     void match_Language_change_the_language() {
         // Given
         GherkinTokenMatcher matcher = new GherkinTokenMatcher("en");


### PR DESCRIPTION
### 🤔 What's changed?

In the `GherkinTokenMatcher`, the `match_StepLine(Token)` method has been optimized using a loop unrolling technique.

### ⚡️ What's your motivation? 

Parsing the BDD files faster.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

When profiling `GherkinParserBenchmarkTest.profileParse()` on the main branch, we see that `match_StepLine(Token)` uses about half of the time to manage the loop and the keywords:
<img width="3484" height="280" alt="image" src="https://github.com/user-attachments/assets/2bbe2757-7897-4aeb-99ec-f11af157bc38" />

The new code consists to unroll the keywords loop for the first 6 step keywords of the language (each language has at least 6 keywords). The 6 keywords length and type is pre-computed.

After the loop unrolling, the profiler shows that loop iterator and `getStepKeywordType` impact is not visible anymore: 
<img width="3496" height="321" alt="image" src="https://github.com/user-attachments/assets/7b8944e0-f28f-4715-ae20-03ec55175f09" />

In terms of performance the profiler shows for `GherkinTokenMatcher.match_StepLine(Token)`:
- main branch from release 33.1.0 : 419 ms
- this version with StepLine loop unrolling: 297 ms (~29% faster)

With the JMH benchmark, the effect is not visible, but on realworld project with 740 BDD scenarios, the ~30% improvement is also visible on the profiler flame graph.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
