### PR TITLE
Revert "Dotnet. Remove version pinning (#455)"

### DIFF
--- a/dotnet/Gherkin/Gherkin.csproj
+++ b/dotnet/Gherkin/Gherkin.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cucumber.Messages" Version="28.1.0" />
+    <PackageReference Include="Cucumber.Messages" Version="[28.0, 29.0)"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### 🤔 What's changed?

This reverts commit 9da43f05322ce8f512554c3ebdf5d37b0e6c8c29.

### ⚡️ What's your motivation? 

Merged with too little discussion.

In #426 I specifically asked for a range, because the messages project churns through majors quite quickly. Most of these don't impact Gherkin. With a version range we can release messages without also having to make major releases for Gherkin.
