### PR TITLE
docs: Correct .NET and berp versions in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ docker run --rm --interactive --tty --volume ".:/app" berp-env
 
 *Or* install on your system
 
-* .NET 8.0 (to run `berp` to generate parsers)
-* `berp` (install with `dotnet tool update Berp --version 1.4.0 --tool-path /usr/bin` )
+* .NET 9.0 (to run `berp` to generate parsers)
+* `berp` (install with `dotnet tool update Berp --version 1.6.0 --tool-path /usr/bin` )
 * `make`
 * `diff`
 


### PR DESCRIPTION
### 🤔 What's changed?

Updated berp and .NET versions in non-docker contributing guidelines to the latest

### ⚡️ What's your motivation? 

Berp v1.4.0 is incompatible with .NET v8 https://github.com/gasparnagy/berp/releases/tag/v1.5.0 and will not work for contributors that are not using the Dockerfile - where the correct versions are specified.

### 🏷️ What kind of change is this?

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

- NA

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)