### PR TITLE
fix: go GitHub workflow cache

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -40,6 +40,7 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go }}
+        cache-dependency-path: go/go.sum
 
     - name: lint
       working-directory: go


### PR DESCRIPTION
### 🤔 What's changed?

Explicit `go` lock file path to enable caching in GitHub workflow.

### ⚡️ What's your motivation? 

Improve CI performance.

Addressing that the [setup-go action](https://github.com/actions/setup-go) expects the lock file at `gherkin/gherkin/go.sum` (see [#50270093623](https://github.com/cucumber/gherkin/actions/runs/17685746857/job/50270093623) logs) rather than `gherkin/go/go.sum`.

```console
Restore cache failed: Dependencies file is not found in /Users/runner/work/gherkin/gherkin. Supported file pattern: go.sum
```

  | Metric | [Previous](https://github.com/cucumber/gherkin/actions/runs/17685746857/job/50270093623) | [Now](https://github.com/cucumber/gherkin/actions/runs/17715534474/job/50339920680) | Delta | % Change |
  |--------|----------|-----|-------|----------|
  | **Total Workflow Runner Time** | [1m 45s<br>(105s)](https://github.com/cucumber/gherkin/actions/runs/17685746857/usage) | [1m 17s<br>(77s)](https://github.com/cucumber/gherkin/actions/runs/17715534474/usage?pr=476) | -28s | -26.7% |
  | **Fastest Job** | [33s](https://github.com/cucumber/gherkin/actions/runs/17685746857/job/50270093608) | [21s](https://github.com/cucumber/gherkin/actions/runs/17715534474/job/50339920680) | -12s | -36.4% |
  | **Average Job** | 35s | 25.6s | -9.4s | -26.9% |

- 26.7% reduction in runner uptime - saving $8.68 and 565 runner minutes compared to [1.4 days total runner usage for this workflow over the past year](https://github.com/cucumber/gherkin/actions/metrics/usage?dateRangeType=DATE_RANGE_TYPE_LAST_YEAR&filters=test-go) (assuming [GitHub Actions pricing](https://docs.github.com/en/billing/concepts/product-billing/github-actions#minute-multipliers))
- 36.4% faster average job execution - continuous feedback in 21s

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)