### PR TITLE
feat: avoid unnecessary String instantiation and codePointCount

### DIFF
--- a/java/src/main/java/io/cucumber/gherkin/StringUtils.java
+++ b/java/src/main/java/io/cucumber/gherkin/StringUtils.java
@@ -10,7 +10,7 @@ final class StringUtils {
      * @return true iff the {@code c} is whitespace and not new line.
      * @see #isWhitespace(char)
      */
-    private static boolean isWhitespaceExcludingNewLine(char c) {
+    static boolean isWhitespaceExcludingNewLine(char c) {
         return c != '\n' && isWhitespace(c);
     }
 
@@ -85,7 +85,7 @@ final class StringUtils {
 
     private static final IndentedText NO_INDENT_ENTRY = new IndentedText(0, "");
 
-    static IndentedText trimAndIndentKeepNewLines(String input) {
+    static IndentedText trimAndIndentKeepNewLines(StringBuilder input) {
         int length = input.length();
         if (length == 0) {
             return NO_INDENT_ENTRY;
@@ -100,11 +100,10 @@ final class StringUtils {
             end--;
         }
         String trimmed = input.substring(start, end);
-        int indent = input.codePointCount(0, start);
         // the object instance is not truly created because
         // the code is inlined by the hotspot compiler
         // (as "-XX:+EliminateAllocations" is enabled by default).
-        return new IndentedText(indent, trimmed);
+        return new IndentedText(start, trimmed);
     }
 
     static IndentedText trimAndIndent(String input) {
@@ -121,11 +120,10 @@ final class StringUtils {
             end--;
         }
         String trimmed = input.substring(start, end);
-        int indent = input.codePointCount(0, start);
         // the object instance is not truly created because
         // the code is inlined by the hotspot compiler
         // (as "-XX:+EliminateAllocations" is enabled by default).
-        return new IndentedText(indent, trimmed);
+        return new IndentedText(start, trimmed);
     }
 
     static boolean containsWhitespace(String input, int fromIndex, int toIndex) {

--- a/java/src/main/java/io/cucumber/gherkin/TableRowLine.java
+++ b/java/src/main/java/io/cucumber/gherkin/TableRowLine.java
@@ -45,7 +45,7 @@ final class TableRowLine {
                         // Skip the first empty span
                         beforeFirst = false;
                     } else {
-                        StringUtils.IndentedText trimmedCellIndent = trimAndIndentKeepNewLines(cellBuilder.toString());
+                        StringUtils.IndentedText trimmedCellIndent = trimAndIndentKeepNewLines(cellBuilder);
                         int column = indent + cellStart + trimmedCellIndent.getIndent() + COLUMN_OFFSET;
                         lineSpans.add(new LineSpan(column, trimmedCellIndent.getText()));
                     }

--- a/java/src/main/java/io/cucumber/gherkin/TagLine.java
+++ b/java/src/main/java/io/cucumber/gherkin/TagLine.java
@@ -26,8 +26,8 @@ final class TagLine {
 
         List<LineSpan> tags = new ArrayList<>();
         int indexEndCurrentTag;
-        int totalCodepointLengthLastIndex = 0;
-        int totalCodepointLength = 0;
+        int indexStartPreviousTag = 0;
+        int totalCodePointCount = 0;
         while (indexStartCurrentTag < indexEndOfLine) {
             // look for the next tag
             int indexStartNextTag = indexStartCurrentTag + 1;
@@ -43,12 +43,12 @@ final class TagLine {
             indexEndCurrentTag++;
 
             if (indexEndCurrentTag > indexStartCurrentTag + 1) {
-                // non-empty tag found
-                // check that the tag does not contain whitespace characters
-                int symbolLength = text.codePointCount(totalCodepointLengthLastIndex, indexStartCurrentTag);
-                totalCodepointLength += symbolLength; // codePointCount is counted incrementally
-                totalCodepointLengthLastIndex = indexStartCurrentTag;
-                int column = indent + totalCodepointLength + COLUMN_OFFSET;
+                // non-empty tag found, check that the tag does not contain whitespace characters
+                
+                // totalCodePointCount is updated incrementally
+                totalCodePointCount += text.codePointCount(indexStartPreviousTag, indexStartCurrentTag); 
+                indexStartPreviousTag = indexStartCurrentTag;
+                int column = indent + totalCodePointCount + COLUMN_OFFSET;
                 if (containsWhitespace(text, indexStartCurrentTag + 1, indexEndCurrentTag)) {
                     throw new ParserException("A tag may not contain whitespace", Locations.atColumn(location, column));
                 }

--- a/java/src/main/java/io/cucumber/gherkin/TagLine.java
+++ b/java/src/main/java/io/cucumber/gherkin/TagLine.java
@@ -26,6 +26,8 @@ final class TagLine {
 
         List<LineSpan> tags = new ArrayList<>();
         int indexEndCurrentTag;
+        int totalCodepointLengthLastIndex = 0;
+        int totalCodepointLength = 0;
         while (indexStartCurrentTag < indexEndOfLine) {
             // look for the next tag
             int indexStartNextTag = indexStartCurrentTag + 1;
@@ -43,8 +45,10 @@ final class TagLine {
             if (indexEndCurrentTag > indexStartCurrentTag + 1) {
                 // non-empty tag found
                 // check that the tag does not contain whitespace characters
-                int symbolLength = text.codePointCount(0, indexStartCurrentTag);
-                int column = indent + symbolLength + COLUMN_OFFSET;
+                int symbolLength = text.codePointCount(totalCodepointLengthLastIndex, indexStartCurrentTag);
+                totalCodepointLength += symbolLength; // codePointCount is counted incrementally
+                totalCodepointLengthLastIndex = indexStartCurrentTag;
+                int column = indent + totalCodepointLength + COLUMN_OFFSET;
                 if (containsWhitespace(text, indexStartCurrentTag + 1, indexEndCurrentTag)) {
                     throw new ParserException("A tag may not contain whitespace", Locations.atColumn(location, column));
                 }

--- a/java/src/test/java/io/cucumber/gherkin/StringUtilsTest.java
+++ b/java/src/test/java/io/cucumber/gherkin/StringUtilsTest.java
@@ -89,4 +89,44 @@ class StringUtilsTest {
                     "Mismatch for char " + (int) c + " '" + c + "'");
         }
     }
+
+    @Test
+    void trimAndIndentKeepNewLines_computes_space_codepoints_correctly() {
+        // When
+        for (char c = Character.MIN_VALUE; c < Character.MAX_VALUE; c++) {
+            if (StringUtils.isWhitespaceExcludingNewLine(c)) {
+                // Given a string with a single whitespace character followed by a non-whitespace character
+                String str = c + "x";
+
+                // When
+                StringUtils.IndentedText trimmedIndent = StringUtils.trimAndIndentKeepNewLines(new StringBuilder(str));
+
+                // Then the indent is the same as the number of codepoints in the whitespace character
+                // (which is always 1 because all whitespace characters are in
+                // the Unicode Basic Multilingual Plane, so are coded on one char)
+                assertEquals(str.codePointCount(0,1), trimmedIndent.getIndent());
+            }
+        }
+    }
+
+
+    @Test
+    void trimAndIndent_computes_space_codepoints_correctly() {
+        // When
+        for (char c = Character.MIN_VALUE; c < Character.MAX_VALUE; c++) {
+            if (StringUtils.isWhitespace(c)) {
+                // Given a string with a single whitespace character followed by a non-whitespace character
+                String str = c + "x";
+
+                // When
+                StringUtils.IndentedText trimmedIndent = StringUtils.trimAndIndent(str);
+
+                // Then the indent is the same as the number of codepoints in the whitespace character
+                // (which is always 1 because all whitespace characters are in
+                // the Unicode Basic Multilingual Plane, so are coded on one char)
+                assertEquals(str.codePointCount(0,1), trimmedIndent.getIndent());
+            }
+        }
+    }
+
 }

--- a/java/src/test/java/io/cucumber/gherkin/TagLineTest.java
+++ b/java/src/test/java/io/cucumber/gherkin/TagLineTest.java
@@ -126,4 +126,14 @@ class TagLineTest {
         List<LineSpan> gherkinLineSpans = parse(0, "", line);
         assertEquals(Collections.emptyList(), gherkinLineSpans);
     }
+
+    @Test
+    void parse_computes_codepoint_column_properly() {
+        // each emoji here is two chars in UTF-16, but one column in Gherkin
+        List<LineSpan> gherkinLineSpans = parse(0, " @😭 @😁 @💺🙄", line);
+        assertEquals(2, gherkinLineSpans.get(0).column);
+        assertEquals(5, gherkinLineSpans.get(1).column);
+        assertEquals(8, gherkinLineSpans.get(2).column);
+    }
+
 }


### PR DESCRIPTION
### 🤔 What's changed?

Some unnecessary operations have been removed:
- `StringUtils.trimAndIndentKeepNewLines(..)` now receive a `StringBuilder` instead of a `String`
- `StringUtils.trimAndIndentKeepNewLines(..)` and `StringUtils.trimAndIndent(..)` now computes the indentation without using codepoints (because all whitespace characters have only 1 character). 
- `TagLine.parse(..)` now computes the codepoints count incrementally (avoids recomputing the codepoint count from the beginning of the string when there are more that one tag on the line).

### ⚡️ What's your motivation? 

Although I didn't benchmark the changes, not doing unnecessary things should be faster.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

I don't think these minor refactoring requires to update the CHANGELOG.md (the benefits in terms of performance would be very small).

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
