### PR TITLE
Add OSGi metadata to the manifest

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-parent</artifactId>
-        <version>4.3.8</version>
+        <version>4.3.9-SNAPSHOT</version>
     </parent>
     <artifactId>gherkin</artifactId>
     <version>35.1.1-SNAPSHOT</version>
@@ -157,6 +157,19 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
             </plugin>
             <!-- Run the code generator -->
             <plugin>


### PR DESCRIPTION
This pull request updates the Maven project configuration in `java/pom.xml`. The main changes are a version bump for the parent POM and the addition of new build plugins to enhance the project's build process.

Dependency and build configuration updates:

* Updated the parent POM version from `4.3.8` to `4.3.9-SNAPSHOT` to track the latest snapshot version.
* Added the `bnd-maven-plugin` for OSGi bundle support and the `maven-jar-plugin` with custom manifest file configuration to the build plugins section.

The summary output is
```
[INFO] The Bundle-SymbolicName is: io.cucumber.gherkin
[INFO] 35.1.1.SNAPSHOT
[INFO] It has 12 requirements:
[INFO]  ✓ Import-Package: io.cucumber.messages; version="[29.0.0,30.0.0)" (provided by io.cucumber:messages:jar:29.0.2-SNAPSHOT)
[INFO]  ✓ Import-Package: io.cucumber.messages.types; version="[29.0.0,30.0.0)" (provided by io.cucumber:messages:jar:29.0.2-SNAPSHOT)
[INFO]  ✓ Import-Package: java.io (provided by the JVM)
[INFO]  ✓ Import-Package: java.lang (provided by the JVM)
[INFO]  ✓ Import-Package: java.lang.invoke (provided by the JVM)
[INFO]  ✓ Import-Package: java.net (provided by the JVM)
[INFO]  ✓ Import-Package: java.nio.charset (provided by the JVM)
[INFO]  ✓ Import-Package: java.nio.file (provided by the JVM)
[INFO]  ✓ Import-Package: java.util (provided by the JVM)
[INFO]  ✓ Import-Package: java.util.function (provided by the JVM)
[INFO]  ✓ Import-Package: java.util.regex (provided by the JVM)
[INFO]  ✓ Import-Package: java.util.stream (provided by the JVM)
[INFO] It provides 1 capabilities:
[INFO]  - Export-Package: io.cucumber.gherkin; bundle-symbolic-name="io.cucumber.gherkin"; bundle-version="35.1.1.SNAPSHOT"; version="35.1.1"; uses:="io.cucumber.messages,io.cucumber.messages.types"
```

the final manifest looks like this

```
Manifest-Version: 1.0
Created-By: Maven JAR Plugin 3.4.2
Build-Jdk-Spec: 21
Specification-Title: Gherkin
Specification-Version: 35.1
Implementation-Title: Gherkin
Implementation-Version: 35.1.1-SNAPSHOT
Automatic-Module-Name: io.cucumber.gherkin
Bundle-Description: Gherkin parser
Bundle-Developers: cucumber;email="devs@cucumber.io";name="Cucumber Deve
 lopers";organization=Cucumber;organizationUrl="https://github.com/cucum
 ber"
Bundle-DocURL: https://github.com/cucumber/gherkin
Bundle-License: "MIT License";link="https://www.opensource.org/licenses/
 mit-license"
Bundle-ManifestVersion: 2
Bundle-Name: Gherkin
Bundle-SCM: url="git://github.com/cucumber/gherkin.git",connection="scm:
 git:git://github.com/cucumber/gherkin.git",developer-connection="scm:gi
 t:git@github.com:cucumber/gherkin.git",tag=HEAD
Bundle-SymbolicName: io.cucumber.gherkin
Bundle-Version: 35.1.1.SNAPSHOT
Export-Package: io.cucumber.gherkin;uses:="io.cucumber.messages,io.cucum
 ber.messages.types";version="35.1.1"
Import-Package: io.cucumber.messages;version="[29.0,30)",io.cucumber.mes
 sages.types;version="[29.0,30)",java.io,java.lang,java.lang.invoke,java
 .net,java.nio.charset,java.nio.file,java.util,java.util.function,java.u
 til.regex,java.util.stream
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
```
