### PR TITLE
Upgrade the PHP static analysis to Psalm 6

### DIFF
--- a/php/bin/gherkin
+++ b/php/bin/gherkin
@@ -13,6 +13,8 @@ $options = ['predictable-ids', 'no-source', 'no-ast', 'no-pickles'];
 
 $selectedOptions = getopt('', $options, $restIndex);
 
+assert($selectedOptions !== false, "getopt returns false only when it cannot find the argv array.");
+
 $paths = array_slice($argv, $restIndex);
 
 // lazily-read list of Sources
@@ -20,7 +22,13 @@ $sources = (
     /** @param list<string> $paths */
     function (array $paths) {
         foreach ($paths as $path) {
-            yield new Source(uri: $path, data: file_get_contents($path));
+            $data = file_get_contents($path);
+
+            if ($data === false) {
+                throw new RuntimeException(sprintf('Unable to read file "%s".', $path));
+            }
+
+            yield new Source(uri: $path, data: $data);
         }
     }
 )($paths);
@@ -34,5 +42,6 @@ $parser = new GherkinParser(
 $envelopes = $parser->parse($sources);
 
 $output = fopen('php://stdout', 'w');
+assert($output !== false);
 $writer = NdJsonStreamWriter::fromFileHandle($output);
 $writer->writeEnvelopes($envelopes);

--- a/php/bin/gherkin-generate-tokens
+++ b/php/bin/gherkin-generate-tokens
@@ -17,9 +17,15 @@ $parser = new Parser(new TokenFormatterBuilder());
 array_shift($argv);
 
 foreach($argv as $fileName) {
+    $input = file_get_contents($fileName);
+
+    if ($input === false) {
+        throw new \RuntimeException(\sprintf('Could not read file "%s".', $fileName));
+    }
+
     $result = $parser->parse(
             $fileName,
-            new StringTokenScanner(file_get_contents($fileName)),
+            new StringTokenScanner($input),
             new TokenMatcher(),
     );
     echo $result;

--- a/php/composer.json
+++ b/php/composer.json
@@ -19,8 +19,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5 || ^11.0",
-        "vimeo/psalm": "5.26.1",
+        "vimeo/psalm": "6.13.1",
         "friendsofphp/php-cs-fixer": "^3.51",
-        "psalm/plugin-phpunit": "^0.19.0"
+        "psalm/plugin-phpunit": "^0.19.5"
     }
 }

--- a/php/psalm.xml
+++ b/php/psalm.xml
@@ -4,6 +4,7 @@
     resolveFromConfigFile="true"
     findUnusedBaselineEntry="true"
     findUnusedCode="true"
+    ensureOverrideAttribute="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
@@ -25,18 +26,6 @@
                 <file name="src-generated/Parser.php"/>
             </errorLevel>
         </TypeDoesNotContainType>
-        <InvalidReturnType>
-            <errorLevel type="suppress">
-                <!-- See https://github.com/vimeo/psalm/issues/8572 -->
-                <file name="src/AstNode.php"/>
-            </errorLevel>
-        </InvalidReturnType>
-        <InvalidReturnStatement>
-            <errorLevel type="suppress">
-                <!-- See https://github.com/vimeo/psalm/issues/8572 -->
-                <file name="src/AstNode.php"/>
-            </errorLevel>
-        </InvalidReturnStatement>
     </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>

--- a/php/src/GherkinDialectProvider.php
+++ b/php/src/GherkinDialectProvider.php
@@ -27,9 +27,12 @@ final class GherkinDialectProvider
         try {
             /**
              * Here we force the type checker to assume the decoded JSON has the correct
-             * structure, rather than validating it. This is safe because it's not dynamic
+             * structure, rather than validating it. This is safe because it's not dynamic.
+             * We also assume that reading the file won't fail as this is a file shipped in
+             * the package.
              *
              * @var non-empty-array<non-empty-string, Dialect> $data
+             * @psalm-suppress PossiblyFalseArgument
              */
             $data = json_decode(file_get_contents(self::JSON_PATH), true, flags: JSON_THROW_ON_ERROR);
             $this->DIALECTS = $data;

--- a/php/src/GherkinDocumentBuilder.php
+++ b/php/src/GherkinDocumentBuilder.php
@@ -26,6 +26,7 @@ use Cucumber\Messages\TableCell;
 use Cucumber\Messages\TableRow;
 use Cucumber\Messages\Tag;
 use LogicException;
+use RuntimeException;
 
 /**
  * @implements Builder<GherkinDocument>
@@ -315,6 +316,10 @@ final class GherkinDocumentBuilder implements Builder
             '',
             $this->joinMatchedTextWithLinebreaks($lineTokens),
         );
+
+        if ($lineText === null) {
+            throw new RuntimeException('Failed to trim the description: ' . preg_last_error_msg());
+        }
 
         return $lineText;
     }

--- a/php/src/StringGherkinLine.php
+++ b/php/src/StringGherkinLine.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Cucumber\Gherkin;
 
+use RuntimeException;
+
 final class StringGherkinLine implements GherkinLine
 {
     // TODO: set this to 0 when/if we change to 0-indexed columns
@@ -93,7 +95,7 @@ final class StringGherkinLine implements GherkinLine
                 // done this way so that \\n => \n once and isn't then recursively replaced again (or similar)
                 $unescaped = preg_replace_callback(
                     '/(\\\\.)/u',
-                    function ($groups) {
+                    function (array $groups) {
                         return match ($groups[0]) {
                             '\\n' => "\n",
                             '\\\\' => '\\',
@@ -103,6 +105,10 @@ final class StringGherkinLine implements GherkinLine
                     },
                     $trimmedCell,
                 );
+
+                if ($unescaped === null) {
+                    throw new \RuntimeException('Failed to decode escape sequences in doc string: ' . preg_last_error_msg());
+                }
 
                 return new GherkinLineSpan($cellStart + $cellIndent + self::OFFSET, $unescaped);
             },
@@ -114,6 +120,10 @@ final class StringGherkinLine implements GherkinLine
     public function getTags(): array
     {
         $uncommentedLine = preg_replace('/\s' . preg_quote(GherkinLanguageConstants::COMMENT_PREFIX) . '.*$/u', '', $this->trimmedLineText);
+
+        if ($uncommentedLine === null) {
+            throw new RuntimeException('Failed to strip comments: ' . preg_last_error_msg());
+        }
 
         /**
          * @var list<array{0:string, 1:int}> $elements guaranteed by PREG_SPLIT_OFFSET_CAPTURE

--- a/php/src/StringUtils.php
+++ b/php/src/StringUtils.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Cucumber\Gherkin;
 
+use RuntimeException;
+
 /**
  * Keeps common string operations in one place using correct unicode functions
  * (and normalises naming with other implementations)
@@ -33,22 +35,46 @@ final class StringUtils
 
     public static function rtrim(string $string): string
     {
-        return preg_replace('/' . self::WHITESPACE_PATTERN . '$/u', '', $string);
+        $trimmed = preg_replace('/' . self::WHITESPACE_PATTERN . '$/u', '', $string);
+
+        if ($trimmed === null) {
+            throw new RuntimeException('Failed to trim the string: ' . preg_last_error_msg());
+        }
+
+        return $trimmed;
     }
 
     public static function rtrimKeepNewLines(string $string): string
     {
-        return preg_replace('/' . self::WHITESPACE_PATTERN_NO_NEWLINE . '$/u', '', $string);
+        $trimmed = preg_replace('/' . self::WHITESPACE_PATTERN_NO_NEWLINE . '$/u', '', $string);
+
+        if ($trimmed === null) {
+            throw new RuntimeException('Failed to trim the string: ' . preg_last_error_msg());
+        }
+
+        return $trimmed;
     }
 
     public static function ltrim(string $string): string
     {
-        return preg_replace('/^'. self::WHITESPACE_PATTERN . '/u', '', $string);
+        $trimmed = preg_replace('/^'. self::WHITESPACE_PATTERN . '/u', '', $string);
+
+        if ($trimmed === null) {
+            throw new RuntimeException('Failed to trim the string: ' . preg_last_error_msg());
+        }
+
+        return $trimmed;
     }
 
     public static function ltrimKeepNewLines(string $string): string
     {
-        return preg_replace('/^'. self::WHITESPACE_PATTERN_NO_NEWLINE . '/u', '', $string);
+        $trimmed = preg_replace('/^'. self::WHITESPACE_PATTERN_NO_NEWLINE . '/u', '', $string);
+
+        if ($trimmed === null) {
+            throw new RuntimeException('Failed to trim the string: ' . preg_last_error_msg());
+        }
+
+        return $trimmed;
     }
 
     public static function trim(string $string): string
@@ -61,7 +87,13 @@ final class StringUtils
     {
         $patterns = array_map(fn ($p) => '/' . preg_quote($p) . '/u', array_keys($replacements));
 
-        return preg_replace($patterns, array_values($replacements), $string);
+        $replaced = preg_replace($patterns, array_values($replacements), $string);
+
+        if ($replaced === null) {
+            throw new RuntimeException('Failed to replace patterns in string: ' . preg_last_error_msg());
+        }
+
+        return $replaced;
     }
 
     /** @return array<non-empty-string> */


### PR DESCRIPTION
### 🤔 What's changed?

This upgrades the tooling used for static analysis of the PHP code, and applies fixes for issues reported by the new version (which are all about cases where version 5 was not enforcing proper error handling in cases where PHP functions use a union type with either `false` or `null` returned on errors).

### ⚡️ What's your motivation? 

Version 5 of Psalm is not maintained anymore and is incompatible with the latest versions of PHP, preventing adding those versions in the CI setup.
I plan to add newer PHP versions in the CI setup as a follow-up.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

I decided to add a dependency on the `composer/pcre` package. This is a small package (maintained by the composer team for usage in Composer itself) providing a type-safe API wrapper around the PCRE API. In particular, failures are reported using exceptions instead of returning `null` and letting you call `preg_last_error_msg()` to get info about the cause of the error.
If you prefer not adding such a dependency, I could add explicit error handling for the PHP API itself in each place using the regex. But it would basically duplicate part of that package, so it might not be worth it.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
