### PR TITLE
[.Net] Replace FluentAssertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org).
 This document is formatted according to the principles of [Keep A CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+- [.Net] Replaced FluentAssertions with AwesomeAssertions
 
 ## [39.1.0] - 2026-05-06
 ### Added

--- a/dotnet/Gherkin.Specs/AstBuildingTests.cs
+++ b/dotnet/Gherkin.Specs/AstBuildingTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Io.Cucumber.Messages.Types;
 using Gherkin.Specs.Helper;
 using Xunit;

--- a/dotnet/Gherkin.Specs/EventTestBase.cs
+++ b/dotnet/Gherkin.Specs/EventTestBase.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 using System.Text;
-using FluentAssertions;
+using AwesomeAssertions;
 using Gherkin.CucumberMessages;
 using Io.Cucumber.Messages.Types;
 using Gherkin.Specs.EventStubs;

--- a/dotnet/Gherkin.Specs/Gherkin.Specs.csproj
+++ b/dotnet/Gherkin.Specs/Gherkin.Specs.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/dotnet/Gherkin.Specs/GherkinDialectTests.cs
+++ b/dotnet/Gherkin.Specs/GherkinDialectTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Xunit;
 
 namespace Gherkin.Specs;

--- a/dotnet/Gherkin.Specs/PicklesTests.cs
+++ b/dotnet/Gherkin.Specs/PicklesTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Io.Cucumber.Messages.Types;
 using Gherkin.Specs.Helper;
 using Xunit;

--- a/dotnet/Gherkin.Specs/SourceTests.cs
+++ b/dotnet/Gherkin.Specs/SourceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Io.Cucumber.Messages.Types;
 using Gherkin.Specs.Helper;
 using Xunit;


### PR DESCRIPTION
### 🤔 What's changed?

.NET - Replaced FluentAssertions with AwesomeAssertions

### ⚡️ What's your motivation? 

For licensing compliance

Contribute to https://github.com/cucumber/common/issues/2314

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
