### PR TITLE
[Elixir] Bump otp-version for workflows

### DIFF
--- a/.github/workflows/release-hex.yaml
+++ b/.github/workflows/release-hex.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
-          otp-version: '27.1'
+          otp-version: '27.3'
           elixir-version: '1.17'
 
       - name: Install Protoc

--- a/.github/workflows/test-elixir.yml
+++ b/.github/workflows/test-elixir.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
       - uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
-          otp-version: '27.1'
+          otp-version: '27.3'
           elixir-version: '1.17'
       - run: |
           mix deps.get


### PR DESCRIPTION
### 🤔 What's changed?

Bump the otp-version in our Elixir workflows from `27.1` to `27.3`.

### ⚡️ What's your motivation?

Gets past [erlang/otp#9208](https://github.com/erlang/otp/issues/9208) which was causing the release to fail with a TLS error.

Ports [cucumber/messages#444](https://github.com/cucumber/messages/pull/444) to this repo.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)