### PR TITLE
ruby: Use current API in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,14 @@ var gherkinDocument = parser.Parse(@"Drive:\PathToGherkinDocument\document.featu
 require 'gherkin/parser'
 require 'gherkin/pickles/compiler'
 
-source = {
+source = Cucumber::Messages::Source.new(
   uri: 'uri_of_the_feature.feature',
   data: 'Feature: ...',
-  mediaType: 'text/x.cucumber.gherkin+plain'
-}
+  media_type: 'text/x.cucumber.gherkin+plain'
+)
 
-gherkin_document = Gherkin::Parser.new.parse(source[:data])
-id_generator = Cucumber::Messages::IdGenerator::UUID.new
+gherkin_document = Gherkin::Parser.new.parse(source.data)
+id_generator = Cucumber::Messages::Helpers::IdGenerator::UUID.new
 
 pickles = Gherkin::Pickles::Compiler.new(id_generator).compile(gherkin_document, source)
 ```


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

Fixes the Ruby README example so it runs with the current  API.

The example now uses `Cucumber::Messages::Source`, the correct `media_type` attribute, `source.data`, and the current UUID ID generator namespace.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

The Ruby snippet in the README had fallen out of sync with the current API.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
