### PR TITLE
remove restore-keys for cpm cache

### DIFF
--- a/.github/workflows/codeql-cpp.yaml
+++ b/.github/workflows/codeql-cpp.yaml
@@ -53,7 +53,6 @@ jobs:
         with:
           path: ${{ env.CPM_SOURCE_CACHE }}
           key: cpm-${{ hashFiles('cpp/cmake/dependencies.cpm.cmake') }}
-          restore-keys: cpm-
 
       - name: Cache ccache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/test-cpp.yml
+++ b/.github/workflows/test-cpp.yml
@@ -77,7 +77,6 @@ jobs:
         with:
           path: ${{ env.CPM_SOURCE_CACHE }}
           key: cpm-${{ hashFiles('cpp/cmake/dependencies.cpm.cmake') }}
-          restore-keys: cpm-
 
       - name: Cache ccache
         if: "!startsWith(matrix.config.os, 'windows')"
@@ -147,7 +146,6 @@ jobs:
         with:
           path: ${{ env.CPM_SOURCE_CACHE }}
           key: cpm-${{ hashFiles('cpp/cmake/dependencies.cpm.cmake') }}
-          restore-keys: cpm-
 
       - name: Cache ccache
         if: "!startsWith(matrix.config.os, 'windows')"


### PR DESCRIPTION
### 🤔 What's changed?

CPM does not clear its cache. reusing an old cache only makes the cache grow bigger.

### ⚡️ What's your motivation? 

Can't have the cache grow too big.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
