### PR TITLE
php: Only downgrade messages when testing with low dependencies

### DIFF
--- a/.github/workflows/test-php.yaml
+++ b/.github/workflows/test-php.yaml
@@ -57,10 +57,9 @@ jobs:
       - name: Install dependencies
         working-directory: php
         run: |
+          composer install
           if [[ "${{ matrix.composer-mode }}" = "low-deps" ]]; then
-            composer update --prefer-lowest
-          else
-            composer install
+            composer update --with-dependencies cucumber/messages --prefer-lowest
           fi
 
       - name: Run tests

--- a/php/composer.json
+++ b/php/composer.json
@@ -18,9 +18,9 @@
         "cucumber/messages": ">=34.0.0 <35"
     },
     "require-dev": {
-        "vimeo/psalm": "6.16.1",
-        "phpunit/phpunit": "13.1.14",
-        "psalm/plugin-phpunit": "0.19.7",
-        "friendsofphp/php-cs-fixer": "3.95.17"
+        "vimeo/psalm": "^6",
+        "phpunit/phpunit": "^13",
+        "psalm/plugin-phpunit": "^0.19",
+        "friendsofphp/php-cs-fixer": "^3"
     }
 }


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Prior to this commit PHP would test with the minimum version of every dependency, including the dev dependencies. Downgrading the test dependencies leads to failing CI when testing against newer PHP versions.

We worked around this by fixing the versions of the dev dependencies but this leads to quite some noise due to co-dependent dependency upgrades.

By downgrading only cucumber/messages we avoid both problems.

### 🏷️ What kind of change is this?
- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
