### PR TITLE
Add German Bavarian and Franconian language support to Gherkin

### DIFF
--- a/gherkin-languages.json
+++ b/gherkin-languages.json
@@ -700,6 +700,109 @@
       "Wenn "
     ]
   },
+  "de-bar": {
+    "and": [
+      "* ",
+      "Und ",
+      "Aa no "
+    ],
+    "background": [
+      "Grundlog",
+      "Vurgschicht"
+    ],
+    "but": [
+      "* ",
+      "Oba ",
+      "Bloß leida "
+    ],
+    "examples": [
+      "Beispuie",
+      "A so schauts aus"
+    ],
+    "feature": [
+      "Mogst a Feature",
+      "Aufgb"
+    ],
+    "given": [
+      "* ",
+      "Gsetzt den Fall ",
+      "Mia ham scho "
+    ],
+    "name": "German Bavarian",
+    "native": "Bairisch",
+    "rule": [
+      "Vaordnung"
+    ],
+    "scenario": [
+      "Gschicht",
+      "Beispui"
+    ],
+    "scenarioOutline": [
+      "Gschicht-Schablone",
+      "Beispui-Vorlog"
+    ],
+    "then": [
+      "* ",
+      "Nacha ",
+      "Dann gschiachts, dass "
+    ],
+    "when": [
+      "* ",
+      "Sobald ",
+      "Wenn oana "
+    ]
+  },
+  "de-fra": {
+    "and": [
+      "* ",
+      "Ah ",
+      "Und aa no "
+    ],
+    "background": [
+      "Vorgschicht",
+      "Grundlaach"
+    ],
+    "but": [
+      "* ",
+      "Aber freilich ned, wenn "
+    ],
+    "examples": [
+      "Beispiele",
+      "Beischbiele wie des hier"
+    ],
+    "feature": [
+      "Sach mer amoi",
+      "Feature"
+    ],
+    "given": [
+      "* ",
+      "Ma stell sich vor ",
+      "Es is halt so, dass "
+    ],
+    "name": "German Franconian",
+    "native": "Fränkisch",
+    "rule": [
+      "Regel, Grundsätzlich"
+    ],
+    "scenario": [
+      "Fall",
+      "Beispiel"
+    ],
+    "scenarioOutline": [
+      "Fall-Schablone",
+      "Beispiel-Vorlaach"
+    ],
+    "then": [
+      "* ",
+      "Nou is ",
+      "Kummt bei raus, dass "
+    ],
+    "when": [
+      "* ",
+      "Sobald ",
+      "Wenn amoi "
+    ]
+  },
   "el": {
     "and": [
       "* ",

--- a/javascript/src/gherkin-languages.json
+++ b/javascript/src/gherkin-languages.json
@@ -700,6 +700,109 @@
       "Wenn "
     ]
   },
+  "de-bar": {
+    "and": [
+      "* ",
+      "Und ",
+      "Aa no "
+    ],
+    "background": [
+      "Grundlog",
+      "Vurgschicht"
+    ],
+    "but": [
+      "* ",
+      "Oba ",
+      "Bloß leida "
+    ],
+    "examples": [
+      "Beispuie",
+      "A so schauts aus"
+    ],
+    "feature": [
+      "Mogst a Feature",
+      "Aufgb"
+    ],
+    "given": [
+      "* ",
+      "Gsetzt den Fall ",
+      "Mia ham scho "
+    ],
+    "name": "German Bavarian",
+    "native": "Bairisch",
+    "rule": [
+      "Vaordnung"
+    ],
+    "scenario": [
+      "Gschicht",
+      "Beispui"
+    ],
+    "scenarioOutline": [
+      "Gschicht-Schablone",
+      "Beispui-Vorlog"
+    ],
+    "then": [
+      "* ",
+      "Nacha ",
+      "Dann gschiachts, dass "
+    ],
+    "when": [
+      "* ",
+      "Sobald ",
+      "Wenn oana "
+    ]
+  },
+  "de-fra": {
+    "and": [
+      "* ",
+      "Ah ",
+      "Und aa no "
+    ],
+    "background": [
+      "Vorgschicht",
+      "Grundlaach"
+    ],
+    "but": [
+      "* ",
+      "Aber freilich ned, wenn "
+    ],
+    "examples": [
+      "Beispiele",
+      "Beischbiele wie des hier"
+    ],
+    "feature": [
+      "Sach mer amoi",
+      "Feature"
+    ],
+    "given": [
+      "* ",
+      "Ma stell sich vor ",
+      "Es is halt so, dass "
+    ],
+    "name": "German Franconian",
+    "native": "Fränkisch",
+    "rule": [
+      "Regel, Grundsätzlich"
+    ],
+    "scenario": [
+      "Fall",
+      "Beispiel"
+    ],
+    "scenarioOutline": [
+      "Fall-Schablone",
+      "Beispiel-Vorlaach"
+    ],
+    "then": [
+      "* ",
+      "Nou is ",
+      "Kummt bei raus, dass "
+    ],
+    "when": [
+      "* ",
+      "Sobald ",
+      "Wenn amoi "
+    ]
+  },
   "el": {
     "and": [
       "* ",

--- a/php/resources/gherkin-languages.json
+++ b/php/resources/gherkin-languages.json
@@ -700,6 +700,109 @@
       "Wenn "
     ]
   },
+  "de-bar": {
+    "and": [
+      "* ",
+      "Und ",
+      "Aa no "
+    ],
+    "background": [
+      "Grundlog",
+      "Vurgschicht"
+    ],
+    "but": [
+      "* ",
+      "Oba ",
+      "Bloß leida "
+    ],
+    "examples": [
+      "Beispuie",
+      "A so schauts aus"
+    ],
+    "feature": [
+      "Mogst a Feature",
+      "Aufgb"
+    ],
+    "given": [
+      "* ",
+      "Gsetzt den Fall ",
+      "Mia ham scho "
+    ],
+    "name": "German Bavarian",
+    "native": "Bairisch",
+    "rule": [
+      "Vaordnung"
+    ],
+    "scenario": [
+      "Gschicht",
+      "Beispui"
+    ],
+    "scenarioOutline": [
+      "Gschicht-Schablone",
+      "Beispui-Vorlog"
+    ],
+    "then": [
+      "* ",
+      "Nacha ",
+      "Dann gschiachts, dass "
+    ],
+    "when": [
+      "* ",
+      "Sobald ",
+      "Wenn oana "
+    ]
+  },
+  "de-fra": {
+    "and": [
+      "* ",
+      "Ah ",
+      "Und aa no "
+    ],
+    "background": [
+      "Vorgschicht",
+      "Grundlaach"
+    ],
+    "but": [
+      "* ",
+      "Aber freilich ned, wenn "
+    ],
+    "examples": [
+      "Beispiele",
+      "Beischbiele wie des hier"
+    ],
+    "feature": [
+      "Sach mer amoi",
+      "Feature"
+    ],
+    "given": [
+      "* ",
+      "Ma stell sich vor ",
+      "Es is halt so, dass "
+    ],
+    "name": "German Franconian",
+    "native": "Fränkisch",
+    "rule": [
+      "Regel, Grundsätzlich"
+    ],
+    "scenario": [
+      "Fall",
+      "Beispiel"
+    ],
+    "scenarioOutline": [
+      "Fall-Schablone",
+      "Beispiel-Vorlaach"
+    ],
+    "then": [
+      "* ",
+      "Nou is ",
+      "Kummt bei raus, dass "
+    ],
+    "when": [
+      "* ",
+      "Sobald ",
+      "Wenn amoi "
+    ]
+  },
   "el": {
     "and": [
       "* ",

--- a/python/src/gherkin/gherkin-languages.json
+++ b/python/src/gherkin/gherkin-languages.json
@@ -700,6 +700,109 @@
       "Wenn "
     ]
   },
+  "de-bar": {
+    "and": [
+      "* ",
+      "Und ",
+      "Aa no "
+    ],
+    "background": [
+      "Grundlog",
+      "Vurgschicht"
+    ],
+    "but": [
+      "* ",
+      "Oba ",
+      "Bloß leida "
+    ],
+    "examples": [
+      "Beispuie",
+      "A so schauts aus"
+    ],
+    "feature": [
+      "Mogst a Feature",
+      "Aufgb"
+    ],
+    "given": [
+      "* ",
+      "Gsetzt den Fall ",
+      "Mia ham scho "
+    ],
+    "name": "German Bavarian",
+    "native": "Bairisch",
+    "rule": [
+      "Vaordnung"
+    ],
+    "scenario": [
+      "Gschicht",
+      "Beispui"
+    ],
+    "scenarioOutline": [
+      "Gschicht-Schablone",
+      "Beispui-Vorlog"
+    ],
+    "then": [
+      "* ",
+      "Nacha ",
+      "Dann gschiachts, dass "
+    ],
+    "when": [
+      "* ",
+      "Sobald ",
+      "Wenn oana "
+    ]
+  },
+  "de-fra": {
+    "and": [
+      "* ",
+      "Ah ",
+      "Und aa no "
+    ],
+    "background": [
+      "Vorgschicht",
+      "Grundlaach"
+    ],
+    "but": [
+      "* ",
+      "Aber freilich ned, wenn "
+    ],
+    "examples": [
+      "Beispiele",
+      "Beischbiele wie des hier"
+    ],
+    "feature": [
+      "Sach mer amoi",
+      "Feature"
+    ],
+    "given": [
+      "* ",
+      "Ma stell sich vor ",
+      "Es is halt so, dass "
+    ],
+    "name": "German Franconian",
+    "native": "Fränkisch",
+    "rule": [
+      "Regel, Grundsätzlich"
+    ],
+    "scenario": [
+      "Fall",
+      "Beispiel"
+    ],
+    "scenarioOutline": [
+      "Fall-Schablone",
+      "Beispiel-Vorlaach"
+    ],
+    "then": [
+      "* ",
+      "Nou is ",
+      "Kummt bei raus, dass "
+    ],
+    "when": [
+      "* ",
+      "Sobald ",
+      "Wenn amoi "
+    ]
+  },
   "el": {
     "and": [
       "* ",

--- a/ruby/lib/gherkin/gherkin-languages.json
+++ b/ruby/lib/gherkin/gherkin-languages.json
@@ -700,6 +700,109 @@
       "Wenn "
     ]
   },
+  "de-bar": {
+    "and": [
+      "* ",
+      "Und ",
+      "Aa no "
+    ],
+    "background": [
+      "Grundlog",
+      "Vurgschicht"
+    ],
+    "but": [
+      "* ",
+      "Oba ",
+      "Bloß leida "
+    ],
+    "examples": [
+      "Beispuie",
+      "A so schauts aus"
+    ],
+    "feature": [
+      "Mogst a Feature",
+      "Aufgb"
+    ],
+    "given": [
+      "* ",
+      "Gsetzt den Fall ",
+      "Mia ham scho "
+    ],
+    "name": "German Bavarian",
+    "native": "Bairisch",
+    "rule": [
+      "Vaordnung"
+    ],
+    "scenario": [
+      "Gschicht",
+      "Beispui"
+    ],
+    "scenarioOutline": [
+      "Gschicht-Schablone",
+      "Beispui-Vorlog"
+    ],
+    "then": [
+      "* ",
+      "Nacha ",
+      "Dann gschiachts, dass "
+    ],
+    "when": [
+      "* ",
+      "Sobald ",
+      "Wenn oana "
+    ]
+  },
+  "de-fra": {
+    "and": [
+      "* ",
+      "Ah ",
+      "Und aa no "
+    ],
+    "background": [
+      "Vorgschicht",
+      "Grundlaach"
+    ],
+    "but": [
+      "* ",
+      "Aber freilich ned, wenn "
+    ],
+    "examples": [
+      "Beispiele",
+      "Beischbiele wie des hier"
+    ],
+    "feature": [
+      "Sach mer amoi",
+      "Feature"
+    ],
+    "given": [
+      "* ",
+      "Ma stell sich vor ",
+      "Es is halt so, dass "
+    ],
+    "name": "German Franconian",
+    "native": "Fränkisch",
+    "rule": [
+      "Regel, Grundsätzlich"
+    ],
+    "scenario": [
+      "Fall",
+      "Beispiel"
+    ],
+    "scenarioOutline": [
+      "Fall-Schablone",
+      "Beispiel-Vorlaach"
+    ],
+    "then": [
+      "* ",
+      "Nou is ",
+      "Kummt bei raus, dass "
+    ],
+    "when": [
+      "* ",
+      "Sobald ",
+      "Wenn amoi "
+    ]
+  },
   "el": {
     "and": [
       "* ",


### PR DESCRIPTION
## Summary

This pull request adds two new Gherkin dialects to `gherkin-languages.json`:

- `de-bar` – German Bavarian
- `de-fra` – German Franconian

The new dialect definitions were then distributed to the language-specific copies of the Gherkin language file, following the repository contribution guidelines.

## Changes

Added the following dialects:

- `de-bar`
  - name: `German Bavarian`
  - native: `Bairisch`

- `de-fra`
  - name: `German Franconian`
  - native: `Fränkisch`

Updated files:

- `gherkin-languages.json`
- `javascript/src/gherkin-languages.json`
- `php/resources/gherkin-languages.json`
- `python/src/gherkin/gherkin-languages.json`
- `ruby/lib/gherkin/gherkin-languages.json`

## Validation

I ran the language distribution step:

- `make clean-gherkin-languages`
- `make copy-gherkin-languages`

I also verified that the generated/copied language files are in sync.

## Notes

I attempted to run `make acceptance` in Codespaces, but the run failed due to a `diff` tool compatibility issue in the environment, unrelated to the dialect changes themselves.