### PR TITLE
Fix double substitutions of example values in Ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ## [Unreleased]
 ### Fixed
 - (i18n) Remove trailing space from Texan Rule keyword.
-- [Ruby] Substitute example values into scenario outlines literally, as the other implementations
-  do, instead of reading them as replacement patterns.
+- [Ruby] Substitute example values into scenario outlines literally, as the other implementations do, instead of reading them as replacement patterns. ([#697](https://github.com/cucumber/gherkin/pull/697))
 
 ## [42.0.1] - 2026-08-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ## [Unreleased]
 ### Fixed
 - (i18n) Remove trailing space from Texan Rule keyword.
+- [Ruby] Substitute example values into scenario outlines literally, as the other implementations
+  do, instead of reading them as replacement patterns.
 
 ## [42.0.1] - 2026-08-05
 ### Added

--- a/ruby/lib/gherkin/pickles/compiler.rb
+++ b/ruby/lib/gherkin/pickles/compiler.rb
@@ -143,7 +143,7 @@ module Gherkin
       def interpolate(name, variable_cells, value_cells)
         variable_cells.each_with_index do |variable_cell, n|
           value_cell = value_cells[n]
-          name = name.gsub('<' + variable_cell.value + '>', value_cell.value)
+          name = name.gsub('<' + variable_cell.value + '>') { value_cell.value }
         end
         name
       end

--- a/ruby/spec/gherkin/pickles/compiler_spec.rb
+++ b/ruby/spec/gherkin/pickles/compiler_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+describe Gherkin::Pickles::Compiler do
+  describe 'interpolation' do
+    def step_texts(value)
+      feature = <<~FEATURE
+        Feature: Interpolation
+
+          Scenario Outline: Substitution
+            Given <value>
+
+            Examples:
+              | value |
+              | #{value} |
+      FEATURE
+
+      Gherkin
+        .from_source('uri', feature, include_pickles: true)
+        .filter_map(&:pickle)
+        .flat_map { |pickle| pickle.steps.map(&:text) }
+    end
+
+    it 'substitutes a value' do
+      expect(step_texts('foo')).to eq(['foo'])
+    end
+
+    it 'substitutes a value with a backslash' do
+      expect(step_texts('a\\\\b')).to eq(['a\b'])
+    end
+
+    it 'substitutes a value with a backtick after a backslash' do
+      expect(step_texts('a\`b')).to eq(['a\`b'])
+    end
+
+    it 'substitutes a value with an ampersand after a backslash' do
+      expect(step_texts('a\&b')).to eq(['a\&b'])
+    end
+  end
+end


### PR DESCRIPTION
### 🤔 What's changed?

The Ruby implementation now substitutes scenario outline example values literally, using the block form of `String#gsub`, instead of passing them as replacement patterns.

### ⚡️ What's your motivation?

Every other implementation already substitutes literally. This is Ruby catching up rather than new behavior.

The second argument of `String#gsub` is a replacement pattern, not a literal string. Because example values are data, any value holding a backslash before special characters is silently rewritten instead of inserted.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

No, I don't think so.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
