### PR TITLE
fix(c): #696 - let user-set CC/AR/LD survive the build

### DIFF
--- a/c/src/Makefile
+++ b/c/src/Makefile
@@ -1,29 +1,27 @@
-GCC_FLAGS=-c -Wall -Werror -g -fPIC 
-CLANG_FLAGS=-c -Wall -Werror -g -fPIC 
-GCC_SO_FLAGS=-shared
-MINGW_FLAGS=-c -Wall -Werror -g 
+# Compiler and tools. These already default to something sensible for the
+# current OS (make's built-in CC is "cc", AR is "ar"), so only set them here
+# if they're not already set - this lets you override them on the command
+# line or via the environment, e.g. `make CC=clang` or
+# `CC=arm-linux-gnueabihf-gcc make`.
+CC ?= gcc
+AR ?= ar
+LD = $(CC)
 
+CFLAGS ?= -Wall -Werror -g -fPIC
+LDFLAGS ?=
+ARFLAGS ?= cr
+SOFLAGS ?= -shared
+
+# Cross-compiling for Windows using mingw needs a few adjustments: no
+# -fPIC, a dedicated archiver, and an .exe extension on the binaries.
 ifeq ($(CC),i686-w64-mingw32-gcc)
-	CC=i686-w64-mingw32-gcc
-	LD=i686-w64-mingw32-gcc
-	CC_FLAGS=$(MINGW_FLAGS)
-	AR=i686-w64-mingw32-ar
-	EXT=.exe
-else ifeq ($(CC),clang)
-	CC=clang
-	LD=clang
-	CC_FLAGS=$(CLANG_FLAGS)
-	AR=ar
-else
-	CC=gcc
-	LD=gcc
-	CC_FLAGS=$(GCC_FLAGS)
-	AR=ar
+	AR = i686-w64-mingw32-ar
+	CFLAGS = -Wall -Werror -g
+	EXT = .exe
 endif
+
 GENERATE_DEPS_FLAGS=-MMD -MP -MF $(basename $@).d
-AR_FLAGS=cr
-LD_FLAGS=
-LD_LIBS=-lm
+LDLIBS=-lm
 RM_CMD=rm -rf
 MKDIR_CMD=mkdir -p
 
@@ -127,20 +125,20 @@ GHERKIN_CLI_OBJS= \
 
 ../objs/%.o: %.c Makefile
 	$(MKDIR_CMD) $(dir $@)
-	$(CC) $(CC_FLAGS) $(GENERATE_DEPS_FLAGS) -I ../include -I . $< -o $@
+	$(CC) -c $(CFLAGS) $(GENERATE_DEPS_FLAGS) -I ../include -I . $< -o $@
 
 ../libs/libgherkin.a: $(UTILITIES_OBJS) $(PARSER_OBJS) $(AST_OBJS) $(COMPILER_OBJS) $(PICKLES_OBJS) $(EVENT_OBJS) Makefile
 	$(MKDIR_CMD) $(dir $@)
-	$(AR) $(AR_FLAGS) $@ $(UTILITIES_OBJS) $(PARSER_OBJS) $(AST_OBJS) $(COMPILER_OBJS) $(PICKLES_OBJS) $(EVENT_OBJS)
+	$(AR) $(ARFLAGS) $@ $(UTILITIES_OBJS) $(PARSER_OBJS) $(AST_OBJS) $(COMPILER_OBJS) $(PICKLES_OBJS) $(EVENT_OBJS)
 
 ../libs/libgherkin.so.$(VERSION): $(UTILITIES_OBJS) $(PARSER_OBJS) $(AST_OBJS) $(COMPILER_OBJS) $(PICKLES_OBJS) $(EVENT_OBJS) Makefile
 	$(MKDIR_CMD) $(dir $@)
-	$(CC) $(GCC_SO_FLAGS) $(UTILITIES_OBJS) $(PARSER_OBJS) $(AST_OBJS) $(COMPILER_OBJS) $(PICKLES_OBJS) $(EVENT_OBJS) -o $@
+	$(CC) $(SOFLAGS) $(UTILITIES_OBJS) $(PARSER_OBJS) $(AST_OBJS) $(COMPILER_OBJS) $(PICKLES_OBJS) $(EVENT_OBJS) -o $@
 
 ../bin/gherkin_generate_tokens$(EXT): ../libs/libgherkin.a $(GENERATE_TOKEN_OBJS) Makefile
 	$(MKDIR_CMD) $(dir $@)
-	$(LD) $(LD_FLAGS) $(GENERATE_TOKEN_OBJS) -L../libs/ -lgherkin $(LD_LIBS) -o $@
+	$(LD) $(LDFLAGS) $(GENERATE_TOKEN_OBJS) -L../libs/ -lgherkin $(LDLIBS) -o $@
 
 ../bin/gherkin$(EXT): ../libs/libgherkin.a $(GHERKIN_CLI_OBJS) Makefile
 	$(MKDIR_CMD) $(dir $@)
-	$(LD) $(LD_FLAGS) $(GHERKIN_CLI_OBJS) -L../libs/ -lgherkin $(LD_LIBS) -o $@
+	$(LD) $(LDFLAGS) $(GHERKIN_CLI_OBJS) -L../libs/ -lgherkin $(LDLIBS) -o $@


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

The `c/src/Makefile` unconditionally reassigned `CC`, `LD` and `AR` inside an `ifeq`/`else` chain. Anything that wasn't literally `clang` or `i686-w64-mingw32-gcc` fell into the `else` branch, which force-set `CC=gcc`, `LD=gcc`, `AR=ar` using plain `=` assignment. Plain `=` assignments silently override environment-set variables (only command-line-set ones are protected in GNU Make), so setting `CC` via the environment e.g. `CC=musl-gcc make` — was discarded and replaced with `gcc` without any warning.

This PR:
- Switches `CC` and `AR` to `?=` so they're only set if the user hasn't already provided a value, otherwise falling back to make's own sensible built-in defaults (`cc`, `ar`) for the current platform.
- Renames the ad-hoc flag variables to the standard GNU Make names: `CC_FLAGS` → `CFLAGS`, `AR_FLAGS` → `ARFLAGS`, `LD_FLAGS` → `LDFLAGS`, `LD_LIBS` → `LDLIBS`, and adds `SOFLAGS` for the shared-library flag.
- Drops the redundant `clang` branch, since its flags were identical to the default.
- Keeps the `i686-w64-mingw32-gcc` special-case, since mingw genuinely needs different flags (no `-fPIC`), a dedicated archiver, and an `.exe` extension.

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->
Fixes #696. The Makefile forced users into gcc/clang/mingw and silently discarded any other compiler set via the environment, even though make's own default `CC`/`AR` values are usually already correct for the current OS.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->
I dropped the `clang` branch entirely since its flags matched the default, want to confirm there wasn't a reason (beyond flags) it was kept separate from the default case. Also open to feedback on whether `SOFLAGS` is the right name, since it's not one of GNU Make's implicit variable names like `CFLAGS`/`ARFLAGS`/`LDFLAGS`.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
- [x] Users should know about my change
- [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
